### PR TITLE
Add flone3.parameric.svg

### DIFF
--- a/flone3.parametric.svg
+++ b/flone3.parametric.svg
@@ -1,0 +1,8664 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:ns5422364="sodipodi"
+   xmlns:ns5245954="inkscape"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="1062.9921"
+   height="1062.9921"
+   id="Flone v3.0"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="flone3.parametric.svg"
+   xmlns:parametric="//parametric-svg.js.org/v1">
+  <metadata
+     id="metadata1351">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1168"
+     inkscape:window-height="670"
+     id="namedview1349"
+     showgrid="false"
+     inkscape:zoom="1.7761186"
+     inkscape:cx="284.23385"
+     inkscape:cy="298.71693"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="Flone v3.0" />
+  <desc
+     id="desc3" />
+  <defs
+     id="defs5">
+    <ref
+       param="mm"
+       default="3.543307692" />
+    <ref
+       param="size"
+       default="4" />
+    <marker
+       refX="0"
+       refY="0"
+       orient="auto"
+       id="DistanceX"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 0,5"
+         id="path3186"
+         style="stroke:#000000;stroke-width:0.5"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <pattern
+       height="8"
+       id="Hatch"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         linecap="square"
+         stroke="#000000"
+         stroke-width="0.25"
+         id="path3189" />
+      <path
+         d="M6 2 l-4,4"
+         linecap="square"
+         stroke="#000000"
+         stroke-width="0.25"
+         id="path3191" />
+      <path
+         d="M4 0 l-4,4"
+         linecap="square"
+         stroke="#000000"
+         stroke-width="0.25"
+         id="path3193" />
+    </pattern>
+    <symbol
+       id="*Model_Space" />
+    <symbol
+       id="*Paper_Space" />
+    <symbol
+       id="*Paper_Space0" />
+    <symbol
+       id="Bloque4">
+      <path
+         d="m 188.30248,1014.9722 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+         id="path3199"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 241.66469,961.66291 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+         id="path3201"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 188.30248,961.61 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+         id="path3203"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 241.51338,1015.0251 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+         id="path3205"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 184.59194,1039.5447 a 54.486732,54.486732 0 0 0 -30.17369,-9.9536"
+         id="path3207"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 154.41825,1029.5911 a 157.56213,157.56213 0 0 0 -84.963564,22.6"
+         id="path3209"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 60.038459,1049.2488 a 10.629921,10.629921 0 0 0 9.416227,2.9423"
+         id="path3211"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 20.543784,1009.7541 a 2.834646,2.834646 0 0 0 -2.318026,-0.8128"
+         id="path3213"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 0.068168,995.89899 a 18.009559,18.009559 0 0 0 18.15759,13.04231"
+         id="path3215"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 1.771654,993.64062 a 1.771654,1.771654 0 0 0 -1.703486,2.25837"
+         id="path3217"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 184.59194,1039.5447 A 58.464567,58.464567 0 1 0 151.61378,979.82173"
+         id="path3219"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 20.543784,1009.7541 39.494675,39.4947"
+         id="path3221"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 202.40485,993.64062 -200.633196,0"
+         id="path3223"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 202.40485,1028.365 0,-34.72438"
+         id="path3225"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 216.22374,1028.365 -13.81889,0"
+         id="path3227"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 216.22374,993.64062 0,34.72438"
+         id="path3229"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 250.06233,993.64062 -33.83859,0"
+         id="path3231"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 250.06233,979.82173 0,13.81889"
+         id="path3233"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 216.22374,979.82173 33.83859,0"
+         id="path3235"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 216.22374,945.09732 0,34.72441"
+         id="path3237"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 202.40485,945.09732 13.81889,0"
+         id="path3239"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 202.40485,979.82173 0,-34.72441"
+         id="path3241"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 151.61378,979.82173 50.79107,0"
+         id="path3243"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+    </symbol>
+    <symbol
+       id="Bloque5">
+      <path
+         d="m 90.46063,1014.9722 a 5.314961,5.314961 0 1 0 -10.629921,0 5.314961,5.314961 0 1 0 10.629921,0 z"
+         id="path3246"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 37.098425,961.66291 a 5.314961,5.314961 0 1 0 -10.629921,0 5.314961,5.314961 0 1 0 10.629921,0 z"
+         id="path3248"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 90.46063,961.61 a 5.314961,5.314961 0 1 0 -10.629921,0 5.314961,5.314961 0 1 0 10.629921,0 z"
+         id="path3250"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 37.249736,1015.0251 a 5.314961,5.314961 0 1 0 -10.629921,0 5.314961,5.314961 0 1 0 10.629921,0 z"
+         id="path3252"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 267.71066,995.89899 a 1.771654,1.771654 0 0 0 -1.34912,-2.25837"
+         parametric:d="`M 26${21.88389-(size*mm)}02,995.89899 A 1.771654,1.771654 0 0 0 266.36154,993.64062`"
+         id="path3254"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 249.90743,1008.9413 a 18.009559,18.009559 0 0 0 17.80323,-13.04231"
+         parametric:d="`M 249.90743,1008.9413 A 18.009559,18.009559 0 0 0 26${21.88389-(size*mm)}02,995.89899`"
+         id="path3256"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 249.90743,1008.9413 a 2.834646,2.834646 0 0 0 -2.31802,0.8128"
+         id="path3258"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 198.67851,1052.1911 a 10.629921,10.629921 0 0 0 9.41622,-2.9423"
+         id="path3260"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 198.67851,1052.1911 a 157.56213,157.56213 0 0 0 -84.96357,-22.6"
+         id="path3262"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 113.71494,1029.5911 a 54.486732,54.486732 0 0 0 -30.173683,9.9536"
+         id="path3264"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 116.51941,979.82173 A 58.464567,58.464567 0 1 0 83.541257,1039.5447"
+         id="path3266"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 116.51941,979.82173 -50.791064,0"
+         id="path3268"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 65.728346,979.82173 0,-34.72441"
+         id="path3270"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 65.728346,945.09732 -13.818897,0"
+         id="path3272"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 51.909449,945.09732 0,34.72441"
+         id="path3274"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 51.909449,979.82173 -33.838583,0"
+         id="path3276"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 18.070866,979.82173 0,13.81889"
+         id="path3278"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 18.070866,993.64062 33.838583,0"
+         id="path3280"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 51.909449,993.64062 0,34.72438"
+         id="path3282"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 51.909449,1028.365 13.818897,0"
+         id="path3284"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 65.728346,993.64062 200.633194,0"
+         id="path3286"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 247.58941,1009.7541 -39.49468,39.4947"
+         id="path3288"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 65.728346,1028.365 0,-34.72438"
+         id="path3290"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+    </symbol>
+    <symbol
+       id="Bloque6">
+      <path
+         d="m 230.42368,974.40945 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+         id="path3293"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 241.79528,846.85039 a 1.771655,1.771655 0 1 0 -3.54331,0 1.771655,1.771655 0 1 0 3.54331,0 z"
+         id="path3295"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 9.744094,889.37008 A 141.73228,141.73228 0 0 0 0,837.72554"
+         id="path3297"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 398.38386,837.63779 a 17.716535,17.716535 0 0 0 -13.84325,6.66031"
+         id="path3299"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 371.87109,850.3937 a 16.214404,16.214404 0 0 0 12.66952,-6.0956"
+         id="path3301"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 303.32371,946.06299 a 1.771654,1.771654 0 0 0 1.70261,-2.26142"
+         id="path3303"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 270.09556,959.05742 a 5.314961,5.314961 0 0 0 7.13279,-4.99443"
+         id="path3305"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 277.22835,975.71226 a 7.086614,7.086614 0 0 0 -4.66285,-6.65923"
+         id="path3307"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 268.17261,1003.0054 a 38.626423,38.626423 0 0 0 9.05574,-24.9258"
+         id="path3309"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 256.46081,1009.2267 a 17.716535,17.716535 0 0 0 11.7118,-6.2213"
+         id="path3311"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 185.30924,930.21302 a 7.354298,7.354298 0 0 0 -7.29349,8.29806"
+         id="path3313"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 191.02463,930.21302 a 11.513773,11.513773 0 0 0 -1.73917,-4.00586"
+         id="path3315"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 189.28546,926.20716 A 10.519727,10.519727 0 0 0 176.38435,919.5413"
+         id="path3317"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 165.58116,912.45468 a 7.086614,7.086614 0 0 0 7.08661,7.08662"
+         id="path3319"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 138.18898,910.62992 a 7.854253,7.854253 0 0 0 -14.17323,0"
+         id="path3321"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 87.69685,910.62992 A 17.716535,17.716535 0 0 0 69.980315,928.34646"
+         id="path3323"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 59.350394,1052.3622 a 10.629921,10.629921 0 0 0 10.629921,-10.6299"
+         id="path3325"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 9.744094,1041.7323 a 10.629921,10.629921 0 0 0 10.629922,10.6299"
+         id="path3327"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 124.01575,835.86614 0,6.02362"
+         id="path3329"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 124.01575,841.88976 14.17323,0"
+         id="path3331"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 138.18898,841.88976 0,-6.02362"
+         id="path3333"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 138.18898,835.86614 -14.17323,0"
+         id="path3335"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 0,822.04724 0,15.6783"
+         id="path3337"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 14.173228,822.04724 0,822.04724"
+         id="path3339"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 14.173228,808.22835 0,13.81889"
+         id="path3341"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 33.838583,808.22835 -19.665355,0"
+         id="path3343"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 33.838583,808.22835 0,53.1496"
+         id="path3345"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 33.838583,861.37795 13.818897,0"
+         id="path3347"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 47.65748,861.37795 0,-53.1496"
+         id="path3349"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 67.322835,822.04724 0,-13.81889"
+         id="path3351"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 360.49606,822.04724 -293.173225,0"
+         id="path3353"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 360.49606,808.22835 0,13.81889"
+         id="path3355"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 413.64567,808.22835 -53.14961,0"
+         id="path3357"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 413.64567,822.04724 0,-13.81889"
+         id="path3359"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 417.18898,822.04724 -3.54331,0"
+         id="path3361"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 417.18898,837.63779 0,-15.59055"
+         id="path3363"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 398.38386,837.63779 18.80512,0"
+         id="path3365"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 310.56937,850.3937 61.30172,0"
+         id="path3367"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 277.22835,946.06299 26.09536,0"
+         id="path3369"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 277.22835,954.06299 0,-8"
+         id="path3371"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 248.88189,951.33628 21.21367,7.72114"
+         id="path3373"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 248.88189,960.4329 0,-9.09662"
+         id="path3375"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 272.5655,969.05303 248.88189,960.4329"
+         id="path3377"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 277.22835,978.0796 0,-2.36734"
+         id="path3379"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 191.02463,930.21302 -5.71539,0"
+         id="path3381"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 172.66777,919.5413 3.71658,0"
+         id="path3383"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 165.58116,910.62992 0,1.82476"
+         id="path3385"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 138.18898,910.62992 27.39218,0"
+         id="path3387"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 69.980315,1041.7323 0,-113.38584"
+         id="path3389"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 20.374016,1052.3622 38.976378,0"
+         id="path3391"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 9.744094,889.37008 0,152.36222"
+         id="path3393"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 67.322835,808.22835 -19.665355,0"
+         id="path3395"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 87.69685,910.62992 36.3189,0"
+         id="path3397"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 305.02632,943.80157 c -3.71434,-12.9123 -20.9326,-46.93375 -20.99894,-66.87999 -0.0707,-21.25654 19.33797,-26.52788 26.54199,-26.52788"
+         id="path3399"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 178.01575,938.51108 c 0.61992,4.7908 9.21439,39.81689 24.8802,56.6819 17.04006,18.34452 42.44653,15.20182 53.56486,14.03372"
+         id="path3401"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+    </symbol>
+    <symbol
+       id="Bloque7">
+      <path
+         d="m 62.893701,1052.3622 a 8.858268,8.858268 0 0 0 8.858268,-8.8583"
+         id="path3404"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 11.515748,1043.5039 a 8.858268,8.858268 0 0 0 8.858268,8.8583"
+         id="path3406"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 72.489943,887.84543 a 35.433071,35.433071 0 0 0 -0.737974,7.19394"
+         id="path3408"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 11.515748,895.03937 a 35.433071,35.433071 0 0 0 -0.737974,-7.19394"
+         id="path3410"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 68.208661,808.22835 -53.149606,0"
+         id="path3412"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 68.208661,822.04724 0,-13.81889"
+         id="path3414"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 83.267717,822.04724 -15.059056,0"
+         id="path3416"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 83.267717,835.86614 0,-13.8189"
+         id="path3418"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 72.489943,887.84543 83.267717,835.86614"
+         id="path3420"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 71.751969,1043.5039 0,-148.46453"
+         id="path3422"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 48.543307,1052.3622 14.350394,0"
+         id="path3424"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 48.543307,861.37795 0,190.98425"
+         id="path3426"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 34.724409,861.37795 13.818898,0"
+         id="path3428"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 34.724409,1052.3622 0,-190.98425"
+         id="path3430"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 20.374016,1052.3622 14.350393,0"
+         id="path3432"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 11.515748,895.03937 0,148.46453"
+         id="path3434"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 0,835.86614 10.777774,51.97929"
+         id="path3436"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 0,822.04724 0,13.8189"
+         id="path3438"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 15.059055,822.04724 0,822.04724"
+         id="path3440"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 15.059055,808.22835 0,13.81889"
+         id="path3442"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+    </symbol>
+    <symbol
+       id="Bloque8">
+      <path
+         d="m 195.06712,863.75116 a 12.401575,12.401575 0 1 0 -24.80315,0 12.401575,12.401575 0 1 0 24.80315,0 z"
+         id="path3445"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 283.02316,798.19998 a 3.543307,3.543307 0 0 0 3.5433,3.54331"
+         id="path3447"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 335.19132,801.74329 a 3.543307,3.543307 0 0 0 1.82302,-0.50495"
+         id="path3449"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 340.11535,793.54754 a 1.771654,1.771654 0 0 0 -1.64311,-2.43417"
+         id="path3451"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 286.56646,791.11337 a 3.543307,3.543307 0 0 0 -3.5433,3.5433"
+         id="path3453"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 365.82753,782.93987 a 12.274894,12.274894 0 0 0 -5.31963,11.61554"
+         id="path3455"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 350.47689,817.47081 a 23.835162,23.835162 0 0 0 10.03101,-22.9154"
+         id="path3457"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 350.47689,817.47081 a 50.383392,50.383392 0 0 0 -0.74204,95.66642"
+         id="path3459"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 359.40919,936.20548 a 23.835162,23.835162 0 0 0 -9.67434,-23.06825"
+         id="path3461"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 359.40919,936.20548 a 14.173228,14.173228 0 0 0 5.28095,10.8873"
+         id="path3463"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 290.04302,1032.7152 a 163.65833,163.65833 0 0 0 -50.54476,12.0716"
+         id="path3465"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 222.12546,1049.5289 a 70.866142,70.866142 0 0 0 17.3728,-4.7421"
+         id="path3467"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 182.66646,1052.3622 a 293.74894,293.74894 0 0 0 39.459,-2.8333"
+         id="path3469"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 143.38301,1049.5074 a 293.67424,293.67424 0 0 0 39.28345,2.8548"
+         id="path3471"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 125.71753,1044.7389 a 70.866142,70.866142 0 0 0 17.66548,4.7685"
+         id="path3473"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 125.71753,1044.7389 A 163.65833,163.65833 0 0 0 75.288061,1032.7152"
+         id="path3475"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 0,945.67844 A 14.173228,14.173228 0 0 0 5.365234,934.83242"
+         id="path3477"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 15.218208,911.8399 A 23.835162,23.835162 0 0 0 5.365234,934.83242"
+         id="path3479"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 15.218208,911.8399 a 50.383392,50.383392 0 0 0 0,-95.66929"
+         id="path3481"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 5.365234,793.17809 a 23.835162,23.835162 0 0 0 9.852974,22.99252"
+         id="path3483"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 5.365234,793.17809 A 12.274894,12.274894 0 0 0 0.135859,781.52164"
+         id="path3485"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 36.909742,726.51405 A 200.19685,200.19685 0 0 0 0.135859,781.52164"
+         id="path3487"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 82.235942,699.86537 A 7.086614,7.086614 0 0 0 71.905596,696.98482"
+         id="path3489"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 82.235942,699.86537 a 146.31135,146.31135 0 0 0 37.478238,48.9903"
+         id="path3491"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 119.71418,748.85567 A 140.25883,140.25883 0 0 0 249.34953,746.9013"
+         id="path3493"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 249.34953,746.9013 a 146.31135,146.31135 0 0 0 35.01374,-46.25204"
+         id="path3495"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 294.71565,697.84892 a 7.086614,7.086614 0 0 0 -10.35238,2.80034"
+         id="path3497"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 286.56646,925.75903 a 3.543307,3.543307 0 0 0 -3.5433,3.54331"
+         id="path3499"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 283.02316,932.84565 a 3.543307,3.543307 0 0 0 3.5433,3.54331"
+         id="path3501"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 338.47224,936.38896 a 1.771654,1.771654 0 0 0 1.64311,-2.43418"
+         id="path3503"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 337.01434,926.26398 a 3.543307,3.543307 0 0 0 -1.82302,-0.50495"
+         id="path3505"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 82.307928,929.30234 a 3.543307,3.543307 0 0 0 -3.543307,-3.54331"
+         id="path3507"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 30.139761,925.75903 a 3.543307,3.543307 0 0 0 -1.823016,0.50495"
+         id="path3509"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 25.215734,933.95478 a 1.771654,1.771654 0 0 0 1.643114,2.43418"
+         id="path3511"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 78.764621,936.38896 a 3.543307,3.543307 0 0 0 3.543307,-3.54331"
+         id="path3513"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 78.764621,801.74329 a 3.543307,3.543307 0 0 0 3.543307,-3.54331"
+         id="path3515"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 82.307928,794.65667 a 3.543307,3.543307 0 0 0 -3.543307,-3.5433"
+         id="path3517"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 26.858848,791.11337 a 1.771654,1.771654 0 0 0 -1.643114,2.43417"
+         id="path3519"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 28.316745,801.23834 a 3.543307,3.543307 0 0 0 1.823016,0.50495"
+         id="path3521"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 101.68124,1007.8005 a 1.63529,1.63529 0 0 0 -0.49536,3.1938"
+         id="path3523"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 101.18588,1010.9943 a 264.82073,264.82073 0 0 0 160.43954,0"
+         id="path3525"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 261.62542,1010.9943 a 1.63529,1.63529 0 0 0 -0.49536,-3.1938"
+         id="path3527"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 290.04302,1032.7152 a 200.19685,200.19685 0 0 0 28.56363,-21.9988"
+         id="path3529"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 328.42134,1000.9883 a 200.19685,200.19685 0 0 0 36.2688,-53.89552"
+         id="path3531"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 71.905596,696.98482 A 200.19685,200.19685 0 0 0 46.724441,716.78587"
+         id="path3533"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 365.82753,782.93987 a 200.19685,200.19685 0 0 0 -36.1967,-55.12981"
+         id="path3535"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 45.42843,1009.507 a 200.19685,200.19685 0 0 0 29.859631,23.2082"
+         id="path3537"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 319.90266,717.99536 A 200.19685,200.19685 0 0 0 294.71565,697.84892"
+         id="path3539"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 0,945.67844 a 200.19685,200.19685 0 0 0 35.700256,54.01382"
+         id="path3541"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 283.02316,794.65667 0,3.54331"
+         id="path3543"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 286.56646,801.74329 48.62486,0"
+         id="path3545"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 337.01434,801.23834 3.10101,-7.6908"
+         id="path3547"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 338.47224,791.11337 -51.90578,0"
+         id="path3549"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 319.90266,717.99536 295.43331,742.4647"
+         id="path3551"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 295.43331,742.4647 9.77144,9.77144"
+         id="path3553"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 305.20475,752.23614 24.42608,-24.42608"
+         id="path3555"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 328.42134,1000.9883 303.952,976.51893"
+         id="path3557"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 303.952,976.51893 -9.77144,9.77143"
+         id="path3559"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 294.18056,986.29036 24.42609,24.42604"
+         id="path3561"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 45.42843,1009.507 69.897775,985.03762"
+         id="path3563"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 69.897775,985.03762 -9.771436,-9.77144"
+         id="path3565"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 60.126339,975.26618 35.700256,999.69226"
+         id="path3567"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 36.909742,726.51405 24.469345,24.46934"
+         id="path3569"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 61.379087,750.98339 9.771436,-9.77143"
+         id="path3571"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 71.150523,741.21196 46.724441,716.78587"
+         id="path3573"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 335.19132,925.75903 -48.62486,0"
+         id="path3575"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 283.02316,929.30234 0,3.54331"
+         id="path3577"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 286.56646,936.38896 51.90578,0"
+         id="path3579"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 340.11535,933.95478 -3.10101,-7.6908"
+         id="path3581"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 82.307928,932.84565 0,-3.54331"
+         id="path3583"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 78.764621,925.75903 -48.62486,0"
+         id="path3585"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 28.316745,926.26398 -3.101011,7.6908"
+         id="path3587"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 26.858848,936.38896 51.905773,0"
+         id="path3589"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 30.139761,801.74329 48.62486,0"
+         id="path3591"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 82.307928,798.19998 0,-3.54331"
+         id="path3593"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 78.764621,791.11337 -51.905773,0"
+         id="path3595"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 25.215734,793.54754 3.101011,7.6908"
+         id="path3597"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 261.13006,1007.8005 -159.44882,0"
+         id="path3599"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+    </symbol>
+    <symbol
+       id="Bloque10">
+      <path
+         d="m 144.62348,969.05303 a 7.086614,7.086614 0 0 0 -4.66285,6.65923"
+         id="path3602"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 396.81496,1052.3622 a 10.629921,10.629921 0 0 0 10.62992,-10.6299"
+         id="path3604"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 417.18898,837.72554 a 141.73228,141.73228 0 0 0 -9.7441,51.64454"
+         id="path3606"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 32.648365,844.2981 A 17.716535,17.716535 0 0 0 18.80512,837.63779"
+         id="path3608"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 32.648365,844.2981 a 16.214404,16.214404 0 0 0 12.669518,6.0956"
+         id="path3610"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 112.16266,943.80157 a 1.771654,1.771654 0 0 0 1.70261,2.26142"
+         id="path3612"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 139.96063,954.06299 a 5.314961,5.314961 0 0 0 7.13278,4.99443"
+         id="path3614"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 139.96063,978.0796 a 38.626423,38.626423 0 0 0 9.05574,24.9258"
+         id="path3616"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 149.01637,1003.0054 a 17.716535,17.716535 0 0 0 11.71179,6.2213"
+         id="path3618"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 239.17323,938.51108 a 7.354298,7.354298 0 0 0 -7.29349,-8.29806"
+         id="path3620"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 227.90352,926.20716 a 11.513773,11.513773 0 0 0 -1.73918,4.00586"
+         id="path3622"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 240.80463,919.5413 a 10.519727,10.519727 0 0 0 -12.90111,6.66586"
+         id="path3624"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 244.5212,919.5413 a 7.086614,7.086614 0 0 0 7.08662,-7.08662"
+         id="path3626"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 293.17323,910.62992 a 7.854253,7.854253 0 0 0 -14.17323,0"
+         id="path3628"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 347.20866,928.34646 A 17.716535,17.716535 0 0 0 329.49213,910.62992"
+         id="path3630"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 347.20866,1041.7323 a 10.629921,10.629921 0 0 0 10.62992,10.6299"
+         id="path3632"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 178.93701,846.85039 a 1.771655,1.771655 0 1 0 -3.54331,0 1.771655,1.771655 0 1 0 3.54331,0 z"
+         id="path3634"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 197.39522,974.40945 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+         id="path3636"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 329.49213,910.62992 -36.3189,0"
+         id="path3638"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 349.86614,808.22835 19.66536,0"
+         id="path3640"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 396.81496,1052.3622 -38.97638,0"
+         id="path3642"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 407.44488,889.37008 0,152.36222"
+         id="path3644"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 417.18898,822.04724 0,15.6783"
+         id="path3646"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 403.01575,822.04724 14.17323,0"
+         id="path3648"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 403.01575,808.22835 0,13.81889"
+         id="path3650"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 383.35039,808.22835 19.66536,0"
+         id="path3652"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 383.35039,861.37795 0,-53.1496"
+         id="path3654"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 369.5315,861.37795 13.81889,0"
+         id="path3656"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 369.5315,808.22835 0,53.1496"
+         id="path3658"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 349.86614,822.04724 0,-13.81889"
+         id="path3660"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 56.692913,822.04724 293.173227,0"
+         id="path3662"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 56.692913,808.22835 0,13.81889"
+         id="path3664"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 3.543307,808.22835 53.149606,0"
+         id="path3666"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 3.543307,822.04724 0,-13.81889"
+         id="path3668"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 0,822.04724 3.543307,0"
+         id="path3670"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 0,837.63779 0,822.04724"
+         id="path3672"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 18.80512,837.63779 0,837.63779"
+         id="path3674"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 106.61961,850.3937 -61.301727,0"
+         id="path3676"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 139.96063,946.06299 -26.09536,0"
+         id="path3678"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 139.96063,954.06299 0,-8"
+         id="path3680"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 168.30709,951.33628 -21.21368,7.72114"
+         id="path3682"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 168.30709,960.4329 0,-9.09662"
+         id="path3684"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 144.62348,969.05303 23.68361,-8.62013"
+         id="path3686"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 139.96063,978.0796 0,-2.36734"
+         id="path3688"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 226.16434,930.21302 5.7154,0"
+         id="path3690"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 244.5212,919.5413 -3.71657,0"
+         id="path3692"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 251.60782,910.62992 0,1.82476"
+         id="path3694"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 279,910.62992 -27.39218,0"
+         id="path3696"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 347.20866,1041.7323 0,-113.38584"
+         id="path3698"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 279,841.88976 0,-6.02362"
+         id="path3700"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 279,835.86614 14.17323,0"
+         id="path3702"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 293.17323,835.86614 0,6.02362"
+         id="path3704"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 293.17323,841.88976 -14.17323,0"
+         id="path3706"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 112.16266,943.80157 c 3.71433,-12.9123 20.93259,-46.93375 20.99894,-66.87999 0.0707,-21.25654 -19.33797,-26.52788 -26.54199,-26.52788"
+         id="path3708"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 239.17323,938.51108 c -0.61992,4.7908 -9.21439,39.81689 -24.8802,56.6819 -17.04007,18.34452 -42.44654,15.20182 -53.56487,14.03372"
+         id="path3710"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+    </symbol>
+    <symbol
+       id="Bloque11">
+      <path
+         d="m 51.467081,1006.2101 a 5.314961,5.314961 0 1 0 -10.629921,0 5.314961,5.314961 0 1 0 10.629921,0 z"
+         id="path3713"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 26.000706,1048.3014 a 46.666434,46.666434 0 0 0 13.242159,4.0608"
+         id="path3715"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 26.000706,1048.3014 A 40.208069,40.208069 0 0 0 4.060832,1026.3615"
+         id="path3717"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 3.668619,986.89925 A 46.666434,46.666434 0 0 0 0,999.30083"
+         id="path3719"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 3.668619,986.89925 A 40.062542,40.062542 0 0 0 26.840904,963.72676"
+         id="path3721"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 66.297927,964.11611 a 46.666434,46.666434 0 0 0 -13.23655,-4.05815"
+         id="path3723"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 66.297927,964.11611 a 40.20805,40.20805 0 0 0 21.945482,21.94256"
+         id="path3725"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 88.148189,1026.4806 a 46.632232,46.632232 0 0 0 3.983901,-12.4983"
+         id="path3727"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 88.148189,1026.4806 a 40.062542,40.062542 0 0 0 -21.714708,21.7203"
+         id="path3729"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 39.242479,960.05802 a 46.666434,46.666434 0 0 0 -12.401575,3.66874"
+         id="path3731"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 92.304184,999.30044 A 46.666434,46.666434 0 0 0 88.243409,986.05867"
+         id="path3733"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 5.8e-5,1013.1197 a 46.666434,46.666434 0 0 0 4.060774,13.2418"
+         id="path3735"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 53.061377,1052.3276 a 46.632232,46.632232 0 0 0 13.372104,-4.1267"
+         id="path3737"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 53.061762,1033.5224 -3.85e-4,18.8052"
+         id="path3739"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 39.242865,1033.5224 13.818897,0"
+         id="path3741"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 39.242865,1052.3622 0,-18.8398"
+         id="path3743"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 18.839768,1013.1197 -18.83971,0"
+         id="path3745"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 18.839768,999.30083 0,13.81887"
+         id="path3747"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 0,999.30083 18.839768,0"
+         id="path3749"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 39.242479,978.89773 0,-18.83971"
+         id="path3751"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 53.061377,978.89773 -13.818898,0"
+         id="path3753"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 53.061377,960.05796 0,18.83977"
+         id="path3755"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 73.464473,999.30044 18.839711,0"
+         id="path3757"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 73.464473,1013.1193 0,-13.81886"
+         id="path3759"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 92.13209,1013.9823 -18.667617,-0.863"
+         id="path3761"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+    </symbol>
+    <symbol
+       id="Bloque13">
+      <path
+         d="m 63.370252,956.8748 a 5.314961,5.314961 0 1 0 -10.629922,0 5.314961,5.314961 0 1 0 10.629922,0 z"
+         id="path3764"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 25.787805,994.45724 a 5.314961,5.314961 0 1 0 -10.629922,0 5.314961,5.314961 0 1 0 10.629922,0 z"
+         id="path3766"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 63.370246,1032.0397 a 5.314961,5.314961 0 1 0 -10.629921,0 5.314961,5.314961 0 1 0 10.629921,0 z"
+         id="path3768"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 100.95269,994.45725 a 5.314961,5.314961 0 1 0 -10.629918,0 5.314961,5.314961 0 1 0 10.629918,0 z"
+         id="path3770"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 63.370252,462.56207 a 5.314961,5.314961 0 1 0 -10.629922,0 5.314961,5.314961 0 1 0 10.629922,0 z"
+         id="path3772"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 632.54722,462.56207 a 5.314965,5.314965 0 1 0 -10.62993,0 5.314965,5.314965 0 1 0 10.62993,0 z"
+         id="path3774"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 100.95269,424.97962 a 5.314961,5.314961 0 1 0 -10.629918,0 5.314961,5.314961 0 1 0 10.629918,0 z"
+         id="path3776"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 632.54722,1032.0397 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+         id="path3778"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 632.54722,956.8748 a 5.314965,5.314965 0 1 0 -10.62993,0 5.314965,5.314965 0 1 0 10.62993,0 z"
+         id="path3780"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 670.12966,994.45724 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+         id="path3782"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 594.96477,994.45725 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+         id="path3784"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 25.787805,424.97962 a 5.314961,5.314961 0 1 0 -10.629922,0 5.314961,5.314961 0 1 0 10.629922,0 z"
+         id="path3786"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 63.370246,387.39717 a 5.314961,5.314961 0 1 0 -10.629921,0 5.314961,5.314961 0 1 0 10.629921,0 z"
+         id="path3788"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 632.54722,387.39717 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+         id="path3790"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 594.96477,424.97962 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+         id="path3792"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 670.12966,424.97962 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+         id="path3794"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 271.30297,730.32405 a 3.543307,3.543307 0 0 0 1.11246,-2.57798"
+         id="path3796"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 272.41543,695.66884 a 3.543307,3.543307 0 0 0 -1.03781,-2.5055"
+         id="path3798"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 264.27899,686.06472 a 3.543307,3.543307 0 0 0 -2.50549,-1.03781"
+         id="path3800"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 247.61228,685.02691 a 3.543307,3.543307 0 0 0 -3.54331,3.54331"
+         id="path3802"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 244.06897,734.63321 a 3.543307,3.543307 0 0 0 3.54331,3.54331"
+         id="path3804"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 261.56814,738.17652 a 3.543307,3.543307 0 0 0 2.43085,-0.96533"
+         id="path3806"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 389.0292,810.97423 a 7.086614,7.086614 0 0 0 -5.01099,-2.07562"
+         id="path3808"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 241.9358,585.74687 a 191.70221,191.70221 0 0 0 201.41595,0"
+         id="path3810"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 478.66705,608.75399 a 3.543307,3.543307 0 0 0 -3.48156,-4.20197"
+         id="path3812"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 219.26582,765.59106 a 2.834646,2.834646 0 0 0 -2.83465,-2.83465"
+         id="path3814"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 209.01298,656.37407 A 174.84443,174.84443 0 0 0 206.6205,608.75399"
+         id="path3816"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 419.13303,919.44281 A 1.771654,1.771654 0 0 0 418.526,916.00675"
+         id="path3818"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 443.35175,585.74687 A 355.21654,355.21654 0 0 0 568.94195,452.93851"
+         id="path3820"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 568.94195,452.93851 a 17.716535,17.716535 0 0 0 1.58123,-12.88697"
+         id="path3822"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 647.49123,479.92581 A 58.218996,58.218996 0 1 0 570.52318,440.05154"
+         id="path3824"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 647.49123,479.92581 a 35.433071,35.433071 0 0 0 -16.75662,13.20934"
+         id="path3826"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 547.62967,598.46085 a 428.74016,428.74016 0 0 0 83.10494,-105.3257"
+         id="path3828"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 547.62967,598.46085 a 177.16535,177.16535 0 0 0 -50.83868,83.96593"
+         id="path3830"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 496.79099,682.42678 A 222.00081,222.00081 0 0 0 496.6098,797.49854"
+         id="path3832"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 496.6098,797.49854 a 250.17122,250.17122 0 0 0 63.00912,105.97297"
+         id="path3834"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 587.62419,931.47679 a 26.55216,26.55216 0 0 0 18.83077,7.77689"
+         id="path3836"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 571.91803,1013.6823 a 58.399827,58.399827 0 1 0 34.53693,-74.42862"
+         id="path3838"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 571.91803,1013.6823 A 54.486732,54.486732 0 0 0 557.62024,985.30801"
+         id="path3840"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 557.62024,985.30801 A 157.56213,157.56213 0 0 0 414.37346,939.3466"
+         id="path3842"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 270.91408,939.3466 a 240.57066,240.57066 0 0 0 143.45938,0"
+         id="path3844"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 270.91408,939.3466 A 157.56213,157.56213 0 0 0 127.66731,985.30801"
+         id="path3846"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 127.66731,985.30801 a 54.486732,54.486732 0 0 0 -14.2978,28.37429"
+         id="path3848"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 78.83259,939.25368 a 58.399827,58.399827 0 1 0 34.53692,74.42862"
+         id="path3850"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 78.83259,939.25368 a 26.55216,26.55216 0 0 0 18.830761,-7.77689"
+         id="path3852"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 125.66863,903.47151 A 250.17122,250.17122 0 0 0 188.67774,797.49854"
+         id="path3854"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 188.67774,797.49854 A 222.00081,222.00081 0 0 0 188.49656,682.42678"
+         id="path3856"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 188.49656,682.42678 A 177.16535,177.16535 0 0 0 137.65788,598.46085"
+         id="path3858"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 54.552931,493.13515 a 428.74016,428.74016 0 0 0 83.104949,105.3257"
+         id="path3860"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 54.552931,493.13515 A 35.433071,35.433071 0 0 0 37.796314,479.92581"
+         id="path3862"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 114.76436,440.05154 A 58.218996,58.218996 0 1 0 37.796314,479.92581"
+         id="path3864"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 114.76436,440.05154 a 17.716535,17.716535 0 0 0 1.58124,12.88697"
+         id="path3866"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 116.3456,452.93851 A 355.21654,355.21654 0 0 0 241.9358,585.74687"
+         id="path3868"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 469.56503,604.55202 a 3.543307,3.543307 0 0 0 -3.5433,3.54331"
+         id="path3870"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 466.02173,656.68045 a 3.543307,3.543307 0 0 0 3.5433,3.54331"
+         id="path3872"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 472.74453,660.22376 a 3.543307,3.543307 0 0 0 3.53004,-3.84969"
+         id="path3874"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 478.66705,608.75399 a 174.84443,174.84443 0 0 0 -2.39248,47.62008"
+         id="path3876"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 211.47054,762.75641 a 2.834646,2.834646 0 0 0 -2.83464,2.83465"
+         id="path3878"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 208.6359,809.89856 a 2.834646,2.834646 0 0 0 2.83464,2.83464"
+         id="path3880"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 216.43117,812.7332 a 2.834646,2.834646 0 0 0 2.83465,-2.83464"
+         id="path3882"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 209.01298,656.37407 a 3.543307,3.543307 0 0 0 3.53003,3.84969"
+         id="path3884"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 215.72251,660.22376 a 3.543307,3.543307 0 0 0 3.54331,-3.54331"
+         id="path3886"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 219.26582,608.09533 a 3.543307,3.543307 0 0 0 -3.54331,-3.54331"
+         id="path3888"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 210.10205,604.55202 a 3.543307,3.543307 0 0 0 -3.48155,4.20197"
+         id="path3890"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 266.76154,916.00675 a 1.771654,1.771654 0 0 0 -0.60703,3.43606"
+         id="path3892"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 266.15451,919.44281 a 223.23737,223.23737 0 0 0 152.97852,0"
+         id="path3894"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 466.02173,809.89856 a 2.834646,2.834646 0 0 0 2.83464,2.83464"
+         id="path3896"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 473.817,812.7332 a 2.834646,2.834646 0 0 0 2.83465,-2.83464"
+         id="path3898"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 476.65165,765.59106 A 2.834646,2.834646 0 0 0 473.817,762.75641"
+         id="path3900"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 468.85637,762.75641 a 2.834646,2.834646 0 0 0 -2.83464,2.83465"
+         id="path3902"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 301.26934,808.89861 a 7.086614,7.086614 0 0 0 -5.01099,2.07562"
+         id="path3904"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 250.53994,856.69264 a 10.629921,10.629921 0 0 0 7.51648,18.14641"
+         id="path3906"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 427.23112,874.83905 a 10.629921,10.629921 0 0 0 7.51649,-18.14641"
+         id="path3908"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 187.57015,591.49566 187.2973,580.24745"
+         id="path3910"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 187.2973,580.24745 -9.87765,-5.38781"
+         id="path3912"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 177.41965,574.85964 -9.60481,5.8604"
+         id="path3914"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 167.81484,580.72004 0.27285,11.2482"
+         id="path3916"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 168.08769,591.96824 9.87765,5.38781"
+         id="path3918"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 177.96534,597.35605 9.60481,-5.86039"
+         id="path3920"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 517.4727,591.49566 -0.27284,-11.24821"
+         id="path3922"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 517.19986,580.24745 -9.87766,-5.38781"
+         id="path3924"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 507.3222,574.85964 -9.6048,5.8604"
+         id="path3926"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 497.7174,580.72004 0.27284,11.2482"
+         id="path3928"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 497.99024,591.96824 9.87765,5.38781"
+         id="path3930"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 507.86789,597.35605 9.60481,-5.86039"
+         id="path3932"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 263.99899,737.21119 7.30398,-6.88714"
+         id="path3934"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 272.41543,727.74607 0,-32.07723"
+         id="path3936"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 271.37762,693.16334 -7.09863,-7.09862"
+         id="path3938"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 261.7735,685.02691 -14.16122,0"
+         id="path3940"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 244.06897,688.57022 0,46.06299"
+         id="path3942"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 247.61228,738.17652 13.95586,0"
+         id="path3944"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 352.52143,715.10624 -0.27285,-11.2482"
+         id="path3946"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 352.24858,703.85804 -9.87765,-5.38781"
+         id="path3948"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 342.37093,698.47023 -9.60481,5.86039"
+         id="path3950"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 332.76612,704.33062 0.27285,11.2482"
+         id="path3952"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 333.03897,715.57882 9.87765,5.38781"
+         id="path3954"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 342.91662,720.96663 9.60481,-5.86039"
+         id="path3956"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 406.4233,697.31686 13.8189,0"
+         id="path3958"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 420.2422,697.31686 0,-24.80315"
+         id="path3960"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 420.2422,672.51371 -13.8189,0"
+         id="path3962"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 406.4233,672.51371 0,24.80315"
+         id="path3964"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 406.4233,750.46646 13.8189,0"
+         id="path3966"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 420.2422,750.46646 0,-24.80315"
+         id="path3968"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 420.2422,725.66331 -13.8189,0"
+         id="path3970"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 406.4233,725.66331 0,24.80315"
+         id="path3972"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 58.399827,435.24592 13.905505,13.90551"
+         id="path3974"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 58.399827,1003.7338 13.905505,13.9055"
+         id="path3976"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 368.09499,725.39821 37.58245,37.58245"
+         id="path3978"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 358.32355,684.26722 395.906,646.68477"
+         id="path3980"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 650.56466,411.56898 -13.9055,13.90551"
+         id="path3982"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 317.19256,725.39821 -37.58245,37.58245"
+         id="path3984"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 326.96399,684.26722 289.38155,646.68477"
+         id="path3986"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 650.56466,980.05687 -13.9055,13.90551"
+         id="path3988"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 466.02173,809.89856 0,-44.3075"
+         id="path3990"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 559.61892,903.47151 28.00527,28.00528"
+         id="path3992"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 125.66863,903.47151 97.663351,931.47679"
+         id="path3994"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 469.56503,604.55202 5.62046,0"
+         id="path3996"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 466.02173,608.09533 0,48.58512"
+         id="path3998"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 472.74453,660.22376 -3.1795,0"
+         id="path4000"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 216.43117,762.75641 -4.96063,0"
+         id="path4002"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 208.6359,765.59106 0,44.3075"
+         id="path4004"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 211.47054,812.7332 4.96063,0"
+         id="path4006"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 219.26582,809.89856 0,-44.3075"
+         id="path4008"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 212.54301,660.22376 3.1795,0"
+         id="path4010"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 219.26582,608.09533 0,48.58512"
+         id="path4012"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 215.72251,604.55202 -5.62046,0"
+         id="path4014"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 72.305332,449.15143 9.771436,-9.77144"
+         id="path4016"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 82.076768,439.37999 68.171263,425.47449"
+         id="path4018"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 68.171263,425.47449 82.076768,411.56898"
+         id="path4020"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 82.076768,411.56898 -9.771436,-9.77144"
+         id="path4022"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 72.305332,401.79754 58.399827,415.70305"
+         id="path4024"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 58.399827,415.70305 44.494321,401.79754"
+         id="path4026"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 44.494321,401.79754 -9.771436,9.77144"
+         id="path4028"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 34.722885,411.56898 48.62839,425.47449"
+         id="path4030"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 48.62839,425.47449 -13.905505,13.9055"
+         id="path4032"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 34.722885,439.37999 9.771436,9.77144"
+         id="path4034"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 44.494321,449.15143 58.399827,435.24592"
+         id="path4036"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 72.305332,1017.6393 9.771436,-9.7714"
+         id="path4038"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 82.076768,1007.8679 68.171263,993.96238"
+         id="path4040"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 68.171263,993.96238 82.076768,980.05687"
+         id="path4042"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 82.076768,980.05687 -9.771436,-9.77143"
+         id="path4044"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 72.305332,970.28544 -13.905505,13.9055"
+         id="path4046"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 58.399827,984.19094 44.494321,970.28544"
+         id="path4048"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 44.494321,970.28544 -9.771436,9.77143"
+         id="path4050"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 34.722885,980.05687 48.62839,993.96238"
+         id="path4052"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 48.62839,993.96238 34.722885,1007.8679"
+         id="path4054"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 34.722885,1007.8679 9.771436,9.7714"
+         id="path4056"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 44.494321,1017.6393 13.905506,-13.9055"
+         id="path4058"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 358.32355,735.16965 9.77144,-9.77144"
+         id="path4060"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 358.32355,735.16965 395.906,772.7521"
+         id="path4062"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 395.906,772.7521 9.77144,-9.77144"
+         id="path4064"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 368.09499,694.03865 -9.77144,-9.77143"
+         id="path4066"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 368.09499,694.03865 405.67744,656.4562"
+         id="path4068"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 405.67744,656.4562 395.906,646.68477"
+         id="path4070"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 640.79322,401.79754 9.77144,9.77144"
+         id="path4072"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 626.88772,415.70305 13.9055,-13.90551"
+         id="path4074"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 612.98221,401.79754 13.90551,13.90551"
+         id="path4076"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 603.21078,411.56898 9.77143,-9.77144"
+         id="path4078"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 617.11628,425.47449 -13.9055,-13.90551"
+         id="path4080"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 603.21078,439.37999 13.9055,-13.9055"
+         id="path4082"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 612.98221,449.15143 -9.77143,-9.77144"
+         id="path4084"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 626.88772,435.24592 -13.90551,13.90551"
+         id="path4086"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 640.79322,449.15143 -13.9055,-13.90551"
+         id="path4088"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 650.56466,439.37999 -9.77144,9.77144"
+         id="path4090"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 636.65916,425.47449 13.9055,13.9055"
+         id="path4092"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 289.38155,772.7521 -9.77144,-9.77144"
+         id="path4094"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 326.96399,735.16965 289.38155,772.7521"
+         id="path4096"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 326.96399,735.16965 -9.77143,-9.77144"
+         id="path4098"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 279.61011,656.4562 9.77144,-9.77143"
+         id="path4100"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 317.19256,694.03865 279.61011,656.4562"
+         id="path4102"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 317.19256,694.03865 9.77143,-9.77143"
+         id="path4104"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 640.79322,970.28544 9.77144,9.77143"
+         id="path4106"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 626.88772,984.19094 13.9055,-13.9055"
+         id="path4108"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 612.98221,970.28544 13.90551,13.9055"
+         id="path4110"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 603.21078,980.05687 9.77143,-9.77143"
+         id="path4112"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 617.11628,993.96238 -13.9055,-13.90551"
+         id="path4114"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 603.21078,1007.8679 13.9055,-13.90552"
+         id="path4116"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 612.98221,1017.6393 -9.77143,-9.7714"
+         id="path4118"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 626.88772,1003.7338 -13.90551,13.9055"
+         id="path4120"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 640.79322,1017.6393 -13.9055,-13.9055"
+         id="path4122"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 650.56466,1007.8679 -9.77144,9.7714"
+         id="path4124"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 636.65916,993.96238 13.9055,13.90552"
+         id="path4126"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 418.526,916.00675 -151.76446,0"
+         id="path4128"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 473.817,812.7332 -4.96063,0"
+         id="path4130"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 476.65165,765.59106 0,44.3075"
+         id="path4132"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 468.85637,762.75641 4.96063,0"
+         id="path4134"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 384.01821,808.89861 -82.74887,0"
+         id="path4136"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 250.53994,856.69264 45.71841,-45.71841"
+         id="path4138"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 258.05642,874.83905 169.1747,0"
+         id="path4140"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 434.74761,856.69264 389.0292,810.97423"
+         id="path4142"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+    </symbol>
+    <symbol
+       id="Bloque14">
+      <path
+         d="m 114.94324,1032.7259 a 3.543307,3.543307 0 0 0 -5.011,0"
+         id="path4145"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 156.35283,1030.589 a 17.716535,17.716535 0 0 0 1.87413,-22.8459"
+         id="path4147"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 125.21755,897.52316 a 177.16535,177.16535 0 0 0 33.00941,110.21994"
+         id="path4149"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 125.21755,897.52316 A 428.74016,428.74016 0 0 0 109.5051,764.28257"
+         id="path4151"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 112.57342,744.34878 a 35.433071,35.433071 0 0 0 -3.06832,19.93379"
+         id="path4153"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 112.57342,744.34878 A 59.118789,59.118789 0 1 0 52.20934,777.811"
+         id="path4155"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 83.731959,953.56544 a 3.543307,3.543307 0 0 0 -5.433066,-0.50941"
+         id="path4157"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 83.731959,953.56544 A 174.84443,174.84443 0 0 0 115.7127,988.92966"
+         id="path4159"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 115.93873,994.14792 a 3.543307,3.543307 0 0 0 -0.22603,-5.21826"
+         id="path4161"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 108.6795,996.39616 a 3.543307,3.543307 0 0 0 5.01099,0"
+         id="path4163"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 74.324627,957.0303 a 3.543307,3.543307 0 0 0 0,5.01099"
+         id="path4165"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 91.114852,692.41626 a 5.314961,5.314961 0 1 0 -10.629922,0 5.314961,5.314961 0 1 0 10.629922,0 z"
+         id="path4167"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 37.761538,745.77846 a 5.314961,5.314961 0 1 0 -10.629921,0 5.314961,5.314961 0 1 0 10.629921,0 z"
+         id="path4169"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 37.752647,692.41626 a 5.314961,5.314961 0 1 0 -10.629921,0 5.314961,5.314961 0 1 0 10.629921,0 z"
+         id="path4171"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 91.114852,745.77847 a 5.314961,5.314961 0 1 0 -10.629922,0 5.314961,5.314961 0 1 0 10.629922,0 z"
+         id="path4173"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 66.028238,726.00681 0,292.28059"
+         id="path4175"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 66.028238,1018.2874 24.764896,24.7649"
+         id="path4177"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 90.793134,1043.0523 10.419546,-1.6069"
+         id="path4179"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 101.21268,1041.4454 8.71956,-8.7195"
+         id="path4181"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 114.94324,1032.7259 19.63634,19.6363"
+         id="path4183"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 134.57958,1052.3622 21.77325,-21.7732"
+         id="path4185"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 52.20934,777.811 0,-51.80419"
+         id="path4187"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 52.20934,726.00681 -34.72441,0"
+         id="path4189"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 17.48493,726.00681 0,-13.8189"
+         id="path4191"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 17.48493,712.18791 34.72441,0"
+         id="path4193"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 52.20934,712.18791 0,-33.83858"
+         id="path4195"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 52.20934,678.34933 13.818898,0"
+         id="path4197"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 66.028238,678.34933 0,33.83858"
+         id="path4199"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 66.028238,712.18791 34.724412,0"
+         id="path4201"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 100.75265,712.18791 0,13.8189"
+         id="path4203"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 100.75265,726.00681 -34.724412,0"
+         id="path4205"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 113.69049,996.39616 2.24824,-2.24824"
+         id="path4207"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 74.324627,962.04129 108.6795,996.39616"
+         id="path4209"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 78.298893,953.05603 -3.974266,3.97427"
+         id="path4211"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+    </symbol>
+    <symbol
+       id="Bloque15">
+      <path
+         d="m 81.056953,745.77847 a 5.314961,5.314961 0 1 0 -10.629921,0 5.314961,5.314961 0 1 0 10.629921,0 z"
+         id="path4214"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 134.41916,692.41626 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+         id="path4216"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 134.41027,745.77846 a 5.314965,5.314965 0 1 0 -10.62993,0 5.314965,5.314965 0 1 0 10.62993,0 z"
+         id="path4218"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 81.056953,692.41626 a 5.314961,5.314961 0 1 0 -10.629921,0 5.314961,5.314961 0 1 0 10.629921,0 z"
+         id="path4220"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 45.829182,988.92966 a 3.543307,3.543307 0 0 0 -0.226033,5.21826"
+         id="path4222"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 47.851394,996.39616 a 3.543307,3.543307 0 0 0 5.010993,0"
+         id="path4224"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 87.217257,962.04129 a 3.543307,3.543307 0 0 0 0,-5.01099"
+         id="path4226"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 83.24299,953.05603 a 3.543307,3.543307 0 0 0 -5.433065,0.50941"
+         id="path4228"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 45.829182,988.92966 A 174.84443,174.84443 0 0 0 77.809925,953.56544"
+         id="path4230"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 51.609639,1032.7259 a 3.543307,3.543307 0 0 0 -5.010993,0"
+         id="path4232"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 3.314919,1007.7431 a 17.716535,17.716535 0 0 0 1.874134,22.8459"
+         id="path4234"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 3.314919,1007.7431 A 177.16535,177.16535 0 0 0 36.324337,897.52316"
+         id="path4236"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 52.03678,764.28257 A 428.74016,428.74016 0 0 0 36.324337,897.52316"
+         id="path4238"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 52.03678,764.28257 A 35.433071,35.433071 0 0 0 48.968467,744.34878"
+         id="path4240"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 109.33254,777.811 A 59.118789,59.118789 0 1 0 48.968467,744.34878"
+         id="path4242"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 47.851394,996.39616 -2.248245,-2.24824"
+         id="path4244"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 87.217257,962.04129 -34.35487,34.35487"
+         id="path4246"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 83.24299,953.05603 3.974267,3.97427"
+         id="path4248"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 95.513646,1018.2874 -24.764897,24.7649"
+         id="path4250"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 70.748749,1043.0523 60.3292,1041.4454"
+         id="path4252"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 60.3292,1041.4454 -8.719561,-8.7195"
+         id="path4254"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 46.598646,1032.7259 -19.636342,19.6363"
+         id="path4256"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 26.962304,1052.3622 5.189053,1030.589"
+         id="path4258"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 109.33254,777.811 0,-51.80419"
+         id="path4260"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 109.33254,726.00681 34.72441,0"
+         id="path4262"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 144.05695,726.00681 0,-13.8189"
+         id="path4264"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 144.05695,712.18791 -34.72441,0"
+         id="path4266"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 109.33254,678.34933 -13.818894,0"
+         id="path4268"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 95.513646,678.34933 0,33.83858"
+         id="path4270"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 95.513646,712.18791 -34.72441,0"
+         id="path4272"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 60.789236,712.18791 0,13.8189"
+         id="path4274"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 60.789236,726.00681 34.72441,0"
+         id="path4276"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 95.513646,726.00681 0,292.28059"
+         id="path4278"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 109.33254,712.18791 0,-33.83858"
+         id="path4280"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+         inkscape:connector-curvature="0" />
+    </symbol>
+  </defs>
+  <g
+     transform="translate(-56.259232,-111.92403)"
+     id="creueta1">
+    <path
+       d="m 466.04076,531.95372 13.78022,13.78024"
+       parametric:d="`M ${471.05175-((size*mm) * 0.353553391)},${526.94273+((size*mm) * 0.353553391)} ${489.84297-((size*mm) * 0.707106782)},545.73396`"
+       id="path7587"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 479.82098,545.73396 -13.78022,13.78023"
+       parametric:d="`M ${489.84297-((size*mm) * 0.707106782)},545.73396 ${471.05175-((size*mm) * 0.353553391)},${564.52518-((size*mm) * 0.353553391)}`"
+       id="path7589"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 466.04076,559.51419 10.02198,10.02198"
+       parametric:d="`M ${471.05175-((size*mm) * 0.353553391)},${564.52518-((size*mm) * 0.353553391)} ${471.05175+((size*mm) * 0.353553391)},${564.52518+((size*mm) * 0.353553391)}`"
+       id="path7591"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 476.06274,569.53617 13.78023,-13.78023"
+       parametric:d="`M ${471.05175+((size*mm) * 0.353553391)},${564.52518+((size*mm) * 0.353553391)} 489.84297,${545.733955+((size*mm) * 0.707106782)}`"
+       id="path7593"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 489.84297,555.75594 13.78024,13.78023"
+       parametric:d="`M 489.84297,${545.733955+((size*mm) * 0.707106782)} ${508.6342-((size*mm) * 0.353553391)},${564.52518+((size*mm) * 0.353553391)}`"
+       id="path7531"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 503.62321,569.53617 10.02198,-10.02198"
+       parametric:d="`M ${508.6342-((size*mm) * 0.353553391)},${564.52518+((size*mm) * 0.353553391)} ${508.6342+((size*mm) * 0.353553391)},${564.52518-((size*mm) * 0.353553391)}`"
+       id="path7573"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 513.64519,559.51419 499.86496,545.73396"
+       parametric:d="`M ${508.6342+((size*mm) * 0.353553391)},${564.52518-((size*mm) * 0.353553391)} ${489.84297+((size*mm) * 0.707106782)},545.73396`"
+       id="path7575"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 499.86496,545.73396 13.78023,-13.78024"
+       parametric:d="`M ${489.84297+((size*mm) * 0.707106782)},545.73396 ${508.6342+((size*mm) * 0.353553391)},${526.94273+((size*mm) * 0.353553391)}`"
+       id="path7577"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 513.64519,531.95372 503.62321,521.93174"
+       parametric:d="`M ${508.6342+((size*mm) * 0.353553391)},${526.94273+((size*mm) * 0.353553391)} ${508.6342-((size*mm) * 0.353553391)},${526.94273-((size*mm) * 0.353553391)}`"
+       id="path7579"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 503.62321,521.93174 -13.78024,13.78023"
+       parametric:d="`M ${508.6342-((size*mm) * 0.353553391)},${526.94273-((size*mm) * 0.353553391)} 489.84297,${545.733955-((size*mm) * 0.707106782)}`"
+       id="path7581"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 489.84297,535.71197 476.06274,521.93174"
+       parametric:d="`M 489.84297,${545.733955-((size*mm) * 0.707106782)} ${471.05175+((size*mm) * 0.353553391)},${526.94273-((size*mm) * 0.353553391)}`"
+       id="path7583"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 476.06274,521.93174 -10.02198,10.02198"
+       parametric:d="`M ${471.05175+((size*mm) * 0.353553391)},${526.94273-((size*mm) * 0.353553391)} ${471.05175-((size*mm) * 0.353553391)},${526.94273+((size*mm) * 0.353553391)}`"
+       id="path7585"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="translate(512.22864,-111.92403)"
+     id="creueta2">
+    <path
+       d="m 466.04076,531.95372 13.78022,13.78024"
+       parametric:d="`M ${471.05175-((size*mm) * 0.353553391)},${526.94273+((size*mm) * 0.353553391)} ${489.84297-((size*mm) * 0.707106782)},545.73396`"
+       id="path577"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 479.82098,545.73396 -13.78022,13.78023"
+       parametric:d="`M ${489.84297-((size*mm) * 0.707106782)},545.73396 ${471.05175-((size*mm) * 0.353553391)},${564.52518-((size*mm) * 0.353553391)}`"
+       id="path579"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 466.04076,559.51419 10.02198,10.02198"
+       parametric:d="`M ${471.05175-((size*mm) * 0.353553391)},${564.52518-((size*mm) * 0.353553391)} ${471.05175+((size*mm) * 0.353553391)},${564.52518+((size*mm) * 0.353553391)}`"
+       id="path581"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 476.06274,569.53617 13.78023,-13.78023"
+       parametric:d="`M ${471.05175+((size*mm) * 0.353553391)},${564.52518+((size*mm) * 0.353553391)} 489.84297,${545.733955+((size*mm) * 0.707106782)}`"
+       id="path583"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 489.84297,555.75594 13.78024,13.78023"
+       parametric:d="`M 489.84297,${545.733955+((size*mm) * 0.707106782)} ${508.6342-((size*mm) * 0.353553391)},${564.52518+((size*mm) * 0.353553391)}`"
+       id="path585"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 503.62321,569.53617 10.02198,-10.02198"
+       parametric:d="`M ${508.6342-((size*mm) * 0.353553391)},${564.52518+((size*mm) * 0.353553391)} ${508.6342+((size*mm) * 0.353553391)},${564.52518-((size*mm) * 0.353553391)}`"
+       id="path587"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 513.64519,559.51419 499.86496,545.73396"
+       parametric:d="`M ${508.6342+((size*mm) * 0.353553391)},${564.52518-((size*mm) * 0.353553391)} ${489.84297+((size*mm) * 0.707106782)},545.73396`"
+       id="path589"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 499.86496,545.73396 13.78023,-13.78024"
+       parametric:d="`M ${489.84297+((size*mm) * 0.707106782)},545.73396 ${508.6342+((size*mm) * 0.353553391)},${526.94273+((size*mm) * 0.353553391)}`"
+       id="path591"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 513.64519,531.95372 503.62321,521.93174"
+       parametric:d="`M ${508.6342+((size*mm) * 0.353553391)},${526.94273+((size*mm) * 0.353553391)} ${508.6342-((size*mm) * 0.353553391)},${526.94273-((size*mm) * 0.353553391)}`"
+       id="path593"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 503.62321,521.93174 -13.78024,13.78023"
+       parametric:d="`M ${508.6342-((size*mm) * 0.353553391)},${526.94273-((size*mm) * 0.353553391)} 489.84297,${545.733955-((size*mm) * 0.707106782)}`"
+       id="path595"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 489.84297,535.71197 476.06274,521.93174"
+       parametric:d="`M 489.84297,${545.733955-((size*mm) * 0.707106782)} ${471.05175+((size*mm) * 0.353553391)},${526.94273-((size*mm) * 0.353553391)}`"
+       id="path597"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 476.06274,521.93174 -10.02198,10.02198"
+       parametric:d="`M ${471.05175+((size*mm) * 0.353553391)},${526.94273-((size*mm) * 0.353553391)} ${471.05175-((size*mm) * 0.353553391)},${526.94273+((size*mm) * 0.353553391)}`"
+       id="path599"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="translate(512.22864,456.56384)"
+     id="creueta3">
+    <path
+       d="m 466.04076,531.95372 13.78022,13.78024"
+       parametric:d="`M ${471.05175-((size*mm) * 0.353553391)},${526.94273+((size*mm) * 0.353553391)} ${489.84297-((size*mm) * 0.707106782)},545.73396`"
+       id="path602"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 479.82098,545.73396 -13.78022,13.78023"
+       parametric:d="`M ${489.84297-((size*mm) * 0.707106782)},545.73396 ${471.05175-((size*mm) * 0.353553391)},${564.52518-((size*mm) * 0.353553391)}`"
+       id="path604"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 466.04076,559.51419 10.02198,10.02198"
+       parametric:d="`M ${471.05175-((size*mm) * 0.353553391)},${564.52518-((size*mm) * 0.353553391)} ${471.05175+((size*mm) * 0.353553391)},${564.52518+((size*mm) * 0.353553391)}`"
+       id="path606"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 476.06274,569.53617 13.78023,-13.78023"
+       parametric:d="`M ${471.05175+((size*mm) * 0.353553391)},${564.52518+((size*mm) * 0.353553391)} 489.84297,${545.733955+((size*mm) * 0.707106782)}`"
+       id="path608"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 489.84297,555.75594 13.78024,13.78023"
+       parametric:d="`M 489.84297,${545.733955+((size*mm) * 0.707106782)} ${508.6342-((size*mm) * 0.353553391)},${564.52518+((size*mm) * 0.353553391)}`"
+       id="path610"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 503.62321,569.53617 10.02198,-10.02198"
+       parametric:d="`M ${508.6342-((size*mm) * 0.353553391)},${564.52518+((size*mm) * 0.353553391)} ${508.6342+((size*mm) * 0.353553391)},${564.52518-((size*mm) * 0.353553391)}`"
+       id="path612"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 513.64519,559.51419 499.86496,545.73396"
+       parametric:d="`M ${508.6342+((size*mm) * 0.353553391)},${564.52518-((size*mm) * 0.353553391)} ${489.84297+((size*mm) * 0.707106782)},545.73396`"
+       id="path614"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 499.86496,545.73396 13.78023,-13.78024"
+       parametric:d="`M ${489.84297+((size*mm) * 0.707106782)},545.73396 ${508.6342+((size*mm) * 0.353553391)},${526.94273+((size*mm) * 0.353553391)}`"
+       id="path616"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 513.64519,531.95372 503.62321,521.93174"
+       parametric:d="`M ${508.6342+((size*mm) * 0.353553391)},${526.94273+((size*mm) * 0.353553391)} ${508.6342-((size*mm) * 0.353553391)},${526.94273-((size*mm) * 0.353553391)}`"
+       id="path618"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 503.62321,521.93174 -13.78024,13.78023"
+       parametric:d="`M ${508.6342-((size*mm) * 0.353553391)},${526.94273-((size*mm) * 0.353553391)} 489.84297,${545.733955-((size*mm) * 0.707106782)}`"
+       id="path620"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 489.84297,535.71197 476.06274,521.93174"
+       parametric:d="`M 489.84297,${545.733955-((size*mm) * 0.707106782)} ${471.05175+((size*mm) * 0.353553391)},${526.94273-((size*mm) * 0.353553391)}`"
+       id="path622"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 476.06274,521.93174 -10.02198,10.02198"
+       parametric:d="`M ${471.05175+((size*mm) * 0.353553391)},${526.94273-((size*mm) * 0.353553391)} ${471.05175-((size*mm) * 0.353553391)},${526.94273+((size*mm) * 0.353553391)}`"
+       id="path624"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="translate(-56.259232,456.56384)"
+     id="creueta4">
+    <path
+       d="m 466.04076,531.95372 13.78022,13.78024"
+       parametric:d="`M ${471.05175-((size*mm) * 0.353553391)},${526.94273+((size*mm) * 0.353553391)} ${489.84297-((size*mm) * 0.707106782)},545.73396`"
+       id="path627"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 479.82098,545.73396 -13.78022,13.78023"
+       parametric:d="`M ${489.84297-((size*mm) * 0.707106782)},545.73396 ${471.05175-((size*mm) * 0.353553391)},${564.52518-((size*mm) * 0.353553391)}`"
+       id="path629"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 466.04076,559.51419 10.02198,10.02198"
+       parametric:d="`M ${471.05175-((size*mm) * 0.353553391)},${564.52518-((size*mm) * 0.353553391)} ${471.05175+((size*mm) * 0.353553391)},${564.52518+((size*mm) * 0.353553391)}`"
+       id="path631"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 476.06274,569.53617 13.78023,-13.78023"
+       parametric:d="`M ${471.05175+((size*mm) * 0.353553391)},${564.52518+((size*mm) * 0.353553391)} 489.84297,${545.733955+((size*mm) * 0.707106782)}`"
+       id="path633"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 489.84297,555.75594 13.78024,13.78023"
+       parametric:d="`M 489.84297,${545.733955+((size*mm) * 0.707106782)} ${508.6342-((size*mm) * 0.353553391)},${564.52518+((size*mm) * 0.353553391)}`"
+       id="path635"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 503.62321,569.53617 10.02198,-10.02198"
+       parametric:d="`M ${508.6342-((size*mm) * 0.353553391)},${564.52518+((size*mm) * 0.353553391)} ${508.6342+((size*mm) * 0.353553391)},${564.52518-((size*mm) * 0.353553391)}`"
+       id="path637"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 513.64519,559.51419 499.86496,545.73396"
+       parametric:d="`M ${508.6342+((size*mm) * 0.353553391)},${564.52518-((size*mm) * 0.353553391)} ${489.84297+((size*mm) * 0.707106782)},545.73396`"
+       id="path639"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 499.86496,545.73396 13.78023,-13.78024"
+       parametric:d="`M ${489.84297+((size*mm) * 0.707106782)},545.73396 ${508.6342+((size*mm) * 0.353553391)},${526.94273+((size*mm) * 0.353553391)}`"
+       id="path641"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 513.64519,531.95372 503.62321,521.93174"
+       parametric:d="`M ${508.6342+((size*mm) * 0.353553391)},${526.94273+((size*mm) * 0.353553391)} ${508.6342-((size*mm) * 0.353553391)},${526.94273-((size*mm) * 0.353553391)}`"
+       id="path643"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 503.62321,521.93174 -13.78024,13.78023"
+       parametric:d="`M ${508.6342-((size*mm) * 0.353553391)},${526.94273-((size*mm) * 0.353553391)} 489.84297,${545.733955-((size*mm) * 0.707106782)}`"
+       id="path645"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 489.84297,535.71197 476.06274,521.93174"
+       parametric:d="`M 489.84297,${545.733955-((size*mm) * 0.707106782)} ${471.05175+((size*mm) * 0.353553391)},${526.94273-((size*mm) * 0.353553391)}`"
+       id="path647"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 476.06274,521.93174 -10.02198,10.02198"
+       parametric:d="`M ${471.05175+((size*mm) * 0.353553391)},${526.94273-((size*mm) * 0.353553391)} ${471.05175-((size*mm) * 0.353553391)},${526.94273+((size*mm) * 0.353553391)}`"
+       id="path649"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="matrix(0,-1,1,0,848.08794,1116.2938)"
+     id="pota darrere1">
+    <path
+       d="m 423.14901,161.04332 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+       id="path8502"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 476.51121,107.73402 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+       id="path8504"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 423.14901,107.68112 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+       id="path8506"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 476.3599,161.09622 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+       id="path8508"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 255.39031,155.82522 39.49468,39.4947"
+       id="path8510"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 437.07421,139.88889 -200.45603,0"
+       parametric:d="`M ${444.160825-((size*mm)/2)},${132.802275+((size*mm)/2)} 236.61818,${132.802275+((size*mm)/2)}`"
+       id="path8512"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 437.07421,174.43612 0,-34.54723"
+       parametric:d="`M ${444.160825-((size*mm)/2)},174.43612 ${444.160825-((size*mm)/2)},${132.802275+((size*mm)/2)}`"
+       id="path8514"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 451.24744,174.43612 -14.17323,0"
+       parametric:d="`M ${444.160825+((size*mm)/2)},174.43612 ${444.160825-((size*mm)/2)},174.43612`"
+       id="path8516"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 451.24744,139.88889 0,34.54723"
+       parametric:d="`M ${444.160825+((size*mm)/2)},${132.802275+((size*mm)/2)} ${444.160825+((size*mm)/2)},174.43612`"
+       id="path8518"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 484.90885,139.88889 -33.66141,0"
+       parametric:d="`M 484.90885,${132.802275+((size*mm)/2)} ${444.160825+((size*mm)/2)},${132.802275+((size*mm)/2)}`"
+       id="path8520"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 484.90885,125.71566 0,14.17323"
+       parametric:d="`M 484.90885,${132.802275-((size*mm)/2)} 484.90885,${132.802275+((size*mm)/2)}`"
+       id="path8522"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 451.24744,125.71566 33.66141,0"
+       parametric:d="`M ${444.160825+((size*mm)/2)},${132.802275-((size*mm)/2)} 484.90885,${132.802275-((size*mm)/2)}`"
+       id="path8524"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 451.24744,91.168421 0,34.547239"
+       parametric:d="`M ${444.160825+((size*mm)/2)},91.168421 ${444.160825+((size*mm)/2)},${132.802275-((size*mm)/2)}`"
+       id="path8526"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 437.07421,91.168421 14.17323,0"
+       parametric:d="`M ${444.160825-((size*mm)/2)},91.168421 ${444.160825+((size*mm)/2)},91.168421`"
+       id="path8528"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 437.07421,125.71566 0,-34.547239"
+       parametric:d="`M ${444.160825-((size*mm)/2)},${132.802275-((size*mm)/2)} ${444.160825-((size*mm)/2)},91.168421`"
+       id="path8530"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 386.46031,125.71566 50.6139,0"
+       parametric:d="`M 386.46031,${132.802275-((size*mm)/2)} ${444.160825-((size*mm)/2)},${132.802275-((size*mm)/2)}`"
+       id="path8532"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 419.43846,185.61582 a 54.486732,54.486732 0 0 0 -30.17369,-9.9536"
+       id="path8534"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 389.26477,175.66222 a 157.56213,157.56213 0 0 0 -84.96356,22.6"
+       id="path8536"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 294.88499,195.31992 a 10.629921,10.629921 0 0 0 9.41622,2.9423"
+       id="path8538"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 255.39031,155.82522 a 2.834646,2.834646 0 0 0 -2.31803,-0.8128"
+       id="path8540"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 234.91469,141.97012 a 18.009559,18.009559 0 0 0 18.15759,13.0423"
+       id="path8542"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 236.61818,139.88889 a 1.771654,1.771654 0 0 0 -1.70349,2.08123"
+       parametric:d="`M 236.61818,${132.802275+((size*mm)/2)} A 1.771654,1.771654 0 0 0 234.91469,141.97012`"
+       id="path8544"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 419.43846,185.61582 A 58.464567,58.464567 0 1 0 386.46031,125.71566"
+       parametric:d="`M 419.43846,185.61582 A 58.464567,58.464567 0 1 0 386.46031,${132.802275-((size*mm)/2)}`"
+       id="path8546"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="matrix(0,1,-1,0,1084.5469,-608.63519)"
+     id="pota davant1">
+    <path
+       d="m 705.00465,115.85709 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+       id="path7159"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 758.36686,62.494891 a 5.314965,5.314965 0 1 0 -10.62993,0 5.314965,5.314965 0 0 0 10.62993,0 z"
+       id="path7161"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 758.35796,115.85709 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+       id="path7163"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 705.00465,62.494891 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+       id="path7165"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 671.79909,366.47479 -2.24824,-2.24825"
+       id="path7167"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 711.16496,332.11992 -34.35487,34.35487"
+       id="path7169"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 707.19069,323.13466 3.97427,3.97427"
+       id="path7171"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 719.28418,388.36598 -24.58773,24.7649"
+       parametric:d="`M ${726.370795-((size*mm)/2)},388.36598 694.69645,413.13088`"
+       id="path7173"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 694.69645,413.13088 684.2769,411.52405"
+       id="path7175"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 684.2769,411.52405 -8.71956,-8.71956"
+       id="path7177"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 670.54634,402.80449 650.91,422.44083"
+       id="path7179"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 650.91,422.44083 629.13675,400.66758"
+       id="path7181"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 733.45741,147.88962 0,-51.627009"
+       parametric:d="`M ${726.370795+((size*mm)/2)},147.88962 ${726.370795+((size*mm)/2)},${89.175996+((size*mm)/2)}`"
+       id="path7183"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 733.45741,96.262611 34.54724,0"
+       parametric:d="`M ${726.370795+((size*mm)/2)},${89.175996+((size*mm)/2)} 768.00465,${89.175996+((size*mm)/2)}`"
+       id="path7185"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 768.00465,96.262611 0,-14.17323"
+       parametric:d="`M 768.00465,${89.175996+((size*mm)/2)} 768.00465,${89.175996-((size*mm)/2)}`"
+       id="path7187"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 768.00465,82.089381 -34.54724,0"
+       parametric:d="`M 768.00465,${89.175996-((size*mm)/2)} ${726.370795+((size*mm)/2)},${89.175996-((size*mm)/2)}`"
+       id="path7189"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 733.45741,48.427961 -14.17323,0"
+       parametric:d="`M ${726.370795+((size*mm)/2)},48.427961 ${726.370795-((size*mm)/2)},48.427961`"
+       id="path7191"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 719.28418,48.427961 0,33.66142"
+       parametric:d="`M ${726.370795-((size*mm)/2)},48.427961 ${726.370795-((size*mm)/2)},${89.175996-((size*mm)/2)}`"
+       id="path7193"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 719.28418,82.089381 -34.54725,0"
+       parametric:d="`M ${726.370795-((size*mm)/2)},${89.175996-((size*mm)/2)} 684.73693,${89.175996-((size*mm)/2)}`"
+       id="path7195"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 684.73693,82.089381 0,14.17323"
+       parametric:d="`M 684.73693,${89.175996-((size*mm)/2)} 684.73693,${89.175996+((size*mm)/2)}`"
+       id="path7197"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 684.73693,96.262611 34.54725,0"
+       parametric:d="`M 684.73693,${89.175996+((size*mm)/2)} ${726.370795-((size*mm)/2)},${89.175996+((size*mm)/2)}`"
+       id="path7199"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 719.28418,96.262611 0,292.103369"
+       parametric:d="`M ${726.370795-((size*mm)/2)},${89.175996+((size*mm)/2)} ${726.370795-((size*mm)/2)},388.36598`"
+       id="path7201"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 733.45741,82.089381 0,-33.66142"
+       parametric:d="`M ${726.370795+((size*mm)/2)},${89.175996-((size*mm)/2)} ${726.370795+((size*mm)/2)},48.427961`"
+       id="path7203"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 669.77688,359.00829 a 3.543307,3.543307 0 0 0 -0.22603,5.21825"
+       id="path7205"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 671.79909,366.47479 a 3.543307,3.543307 0 0 0 5.011,0"
+       id="path7207"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 711.16496,332.11992 a 3.543307,3.543307 0 0 0 0,-5.01099"
+       id="path7209"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 707.19069,323.13466 a 3.543307,3.543307 0 0 0 -5.43307,0.50941"
+       id="path7211"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 669.77688,359.00829 a 174.84443,174.84443 0 0 0 31.98074,-35.36422"
+       id="path7213"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 675.55734,402.80449 a 3.543307,3.543307 0 0 0 -5.011,0"
+       id="path7215"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 627.26262,377.82171 a 17.716535,17.716535 0 0 0 1.87413,22.84587"
+       id="path7217"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 627.26262,377.82171 A 177.16535,177.16535 0 0 0 660.27204,267.60178"
+       id="path7219"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 675.98448,134.36119 A 428.74016,428.74016 0 0 0 660.27204,267.60178"
+       id="path7221"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 675.98448,134.36119 A 35.433071,35.433071 0 0 0 672.91617,114.4274"
+       id="path7223"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 733.45741,147.88962 A 59.118789,59.118789 0 1 0 672.91617,114.4274"
+       parametric:d="`M ${726.370795+((size*mm)/2)},147.88962 A 59.118789,59.118789 0 1 0 672.91617,114.4274`"
+       id="path7225"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="matrix(0,-1,1,0,264.47065,1146.6538)"
+     id="pota davant2">
+    <path
+       d="M 971.42734,209.02051 A 59.118789,59.118789 0 1 0 910.8861,242.48272"
+       parametric:d="`M 971.42734,209.02051 A 59.118789,59.118789 0 1 0 ${917.972715-((size*mm)/2)},242.48272`"
+       id="path7327"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 949.96877,210.45019 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+       id="path7271"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 896.60657,157.08799 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+       id="path7273"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 896.61546,210.45019 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+       id="path7275"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 949.96877,157.08799 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+       id="path7277"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 937.15282,417.72774 -3.97427,3.9743"
+       id="path7279"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 933.17855,426.71304 34.35487,34.3549"
+       id="path7281"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 972.54441,461.06794 2.24825,-2.2483"
+       id="path7283"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 959.60657,190.85571 -34.54724,0"
+       parametric:d="`M 959.60657,${183.769095+((size*mm)/2)} ${917.972715+((size*mm)/2)},${183.769095+((size*mm)/2)}`"
+       id="path7285"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 959.60657,176.68248 0,14.17323"
+       parametric:d="`M 959.60657,${183.769095-((size*mm)/2)} 959.60657,${183.769095+((size*mm)/2)}`"
+       id="path7287"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 925.05933,176.68248 34.54724,0"
+       parametric:d="`M ${917.972715+((size*mm)/2)},${183.769095-((size*mm)/2)} 959.60657,${183.769095-((size*mm)/2)}`"
+       id="path7289"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 925.05933,143.02106 0,33.66142"
+       parametric:d="`M ${917.972715+((size*mm)/2)},143.02106 ${917.972715+((size*mm)/2)},${183.769095-((size*mm)/2)}`"
+       id="path7291"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 910.8861,143.02106 14.17323,0"
+       parametric:d="`M ${917.972715-((size*mm)/2)},143.02106 ${917.972715+((size*mm)/2)},143.02106`"
+       id="path7293"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 910.8861,176.68248 0,-33.66142"
+       parametric:d="`M ${917.972715-((size*mm)/2)},${183.769095-((size*mm)/2)} ${917.972715-((size*mm)/2)},143.02106`"
+       id="path7295"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 876.33885,176.68248 34.54725,0"
+       parametric:d="`M 876.33885,${183.769095-((size*mm)/2)} ${917.972715-((size*mm)/2)},${183.769095-((size*mm)/2)}`"
+       id="path7297"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 876.33885,190.85571 0,-14.17323"
+       parametric:d="`M 876.33885,${183.769095+((size*mm)/2)} 876.33885,${183.769095-((size*mm)/2)}`"
+       id="path7299"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 910.8861,190.85571 -34.54725,0"
+       parametric:d="`M ${917.972715-((size*mm)/2)},${183.769095+((size*mm)/2)} 876.33885,${183.769095+((size*mm)/2)}`"
+       id="path7301"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 910.8861,242.48272 0,-51.62701"
+       parametric:d="`M ${917.972715-((size*mm)/2)},242.48272 ${917.972715-((size*mm)/2)},${183.769095+((size*mm)/2)}`"
+       id="path7303"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 993.4335,517.03394 21.7733,-21.7733"
+       id="path7305"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 973.79716,497.39764 19.63634,19.6363"
+       id="path7307"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 960.06661,506.11714 8.71956,-8.7195"
+       id="path7309"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 949.64706,507.72394 10.41955,-1.6068"
+       id="path7311"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 925.05933,482.95904 24.58773,24.7649"
+       parametric:d="`M ${917.972715+((size*mm)/2)},482.95904 949.64706,507.72394`"
+       id="path7313"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 925.05933,190.85571 0,292.10333"
+       parametric:d="`M ${917.972715+((size*mm)/2)},${183.769095+((size*mm)/2)} ${917.972715+((size*mm)/2)},482.95904`"
+       id="path7315"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 933.17855,421.70204 a 3.543307,3.543307 0 0 0 0,5.011"
+       id="path7317"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 967.53342,461.06794 a 3.543307,3.543307 0 0 0 5.01099,0"
+       id="path7319"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 974.79266,458.81964 a 3.543307,3.543307 0 0 0 -0.22603,-5.2182"
+       id="path7321"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 942.58588,418.23714 a 174.84443,174.84443 0 0 0 31.98075,35.3643"
+       id="path7323"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 942.58588,418.23714 a 3.543307,3.543307 0 0 0 -5.43306,-0.5094"
+       id="path7325"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 971.42734,209.02051 a 35.433071,35.433071 0 0 0 -3.06831,19.93379"
+       id="path7329"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 984.07147,362.19489 A 428.74016,428.74016 0 0 0 968.35903,228.9543"
+       id="path7331"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 984.07147,362.19489 a 177.16535,177.16535 0 0 0 33.00943,110.21995"
+       id="path7333"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1015.2068,495.26064 a 17.716535,17.716535 0 0 0 1.8741,-22.8458"
+       id="path7335"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 973.79716,497.39764 a 3.543307,3.543307 0 0 0 -5.01099,0"
+       id="path7337"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="translate(242.67955,-547.84734)"
+     id="suport XT60">
+    <path
+       d="m 350.68657,637.98505 6.20163,-5.4264"
+       id="path7364"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 356.8882,632.55865 0,-9.7441"
+       id="path7366"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 356.8882,622.81455 -10.62992,-9.3012"
+       id="path7368"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 346.25828,613.51335 -44.29134,0"
+       id="path7370"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 301.96694,613.51335 0,28.3465"
+       id="path7372"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 301.96694,641.85985 1.90713,0"
+       id="path7374"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 305.64572,643.63145 0,12.4016"
+       id="path7376"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 356.8882,656.03305 -7.02473,-13.7713"
+       id="path7378"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 295.76616,592.25355 -12.40158,0"
+       id="path7380"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 295.76616,578.08032 0,14.17323"
+       parametric:d="`M 295.76616,${592.25355-(size*mm)} 295.76616,592.25355`"
+       id="path7382"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 320.56931,578.08032 -24.80315,0"
+       parametric:d="`M 320.56931,${592.25355-(size*mm)} 295.76616,${592.25355-(size*mm)}`"
+       id="path7384"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 320.56931,592.25355 0,-14.17323"
+       parametric:d="`M 320.56931,592.25355 320.56931,${592.25355-(size*mm)}`"
+       id="path7386"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 348.91576,592.25355 -28.34645,0"
+       id="path7388"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 348.91576,578.08032 0,14.17323"
+       parametric:d="`M 348.91576,${592.25355-(size*mm)} 348.91576,592.25355`"
+       id="path7390"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 373.71891,578.08032 -24.80315,0"
+       parametric:d="`M 373.71891,${592.25355-(size*mm)} 348.91576,${592.25355-(size*mm)}`"
+       id="path7392"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 373.71891,592.25355 0,-14.17323"
+       parametric:d="`M 373.71891,592.25355 373.71891,${592.25355-(size*mm)}`"
+       id="path7394"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 388.24647,592.25355 -14.52756,0"
+       id="path7396"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 388.24647,656.03305 0,-63.7795"
+       id="path7398"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 283.36458,656.03305 22.28114,0"
+       id="path7400"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 283.36458,592.25355 0,63.7795"
+       id="path7402"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 356.8882,656.03305 31.35827,0"
+       id="path7404"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 350.68657,637.98505 a 3.543307,3.543307 0 0 0 -0.8231,4.2767"
+       id="path7406"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 305.64572,643.63145 a 1.771654,1.771654 0 0 0 -1.77165,-1.7716"
+       id="path7408"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="translate(-56.259232,-111.92403)"
+     id="frame">
+    <path
+       d="m 494.8134,1077.1343 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+       id="path7435"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 457.23095,1114.7167 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+       id="path7437"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 494.81339,1152.2992 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+       id="path7439"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 532.39584,1114.7167 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+       id="path7441"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 494.8134,582.82154 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+       id="path7443"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1063.9904,582.82154 a 5.315,5.315 0 1 0 -10.63,0 5.315,5.315 0 1 0 10.63,0 z"
+       id="path7445"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 532.39584,545.23909 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+       id="path7447"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1063.9904,1152.2992 a 5.315,5.315 0 1 0 -10.63,0 5.315,5.315 0 1 0 10.63,0 z"
+       id="path7449"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1063.9904,1077.1343 a 5.315,5.315 0 1 0 -10.63,0 5.315,5.315 0 1 0 10.63,0 z"
+       id="path7451"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1101.5728,1114.7167 a 5.314961,5.314961 0 1 0 -10.6299,0 5.314961,5.314961 0 1 0 10.6299,0 z"
+       id="path7453"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1026.4079,1114.7167 a 5.314961,5.314961 0 1 0 -10.6299,0 5.314961,5.314961 0 1 0 10.6299,0 z"
+       id="path7455"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 457.23095,545.23909 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+       id="path7457"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 494.81339,507.65664 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+       id="path7459"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1063.9904,507.65664 a 5.315,5.315 0 1 0 -10.63,0 5.315,5.315 0 1 0 10.63,0 z"
+       id="path7461"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1026.4079,545.23909 a 5.314961,5.314961 0 1 0 -10.6299,0 5.314961,5.314961 0 1 0 10.6299,0 z"
+       id="path7463"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1101.5728,545.23909 a 5.314961,5.314961 0 1 0 -10.6299,0 5.314961,5.314961 0 1 0 10.6299,0 z"
+       id="path7465"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 619.0133,711.75513 -0.27285,-11.2482"
+       id="path7467"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 618.74045,700.50693 -9.87765,-5.38781"
+       id="path7469"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 608.8628,695.11912 -9.60481,5.86039"
+       id="path7471"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 599.25799,700.97951 0.27285,11.2482"
+       id="path7473"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 599.53084,712.22771 9.87765,5.38781"
+       id="path7475"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 609.40849,717.61552 9.60481,-5.86039"
+       id="path7477"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 948.91585,711.75513 948.643,700.50693"
+       id="path7479"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 948.643,700.50693 -9.87765,-5.38781"
+       id="path7481"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 938.76535,695.11912 -9.60481,5.86039"
+       id="path7483"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 929.16054,700.97951 0.27285,11.2482"
+       id="path7485"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 929.43339,712.22771 9.87765,5.38781"
+       id="path7487"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 939.31104,717.61552 9.60481,-5.86039"
+       id="path7489"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 695.44214,857.4707 7.30398,-6.8872"
+       id="path7491"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 703.85858,848.0055 0,-32.0772"
+       id="path7493"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 702.82077,813.4228 -7.09862,-7.0986"
+       id="path7495"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 693.21665,805.2864 -14.16122,0"
+       id="path7497"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 675.51212,808.8297 0,46.063"
+       id="path7499"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 679.05543,858.436 13.95586,0"
+       id="path7501"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 783.96458,835.3657 -0.27285,-11.2482"
+       id="path7503"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 783.69173,824.1175 -9.87765,-5.3878"
+       id="path7505"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 773.81408,818.7297 -9.60481,5.8604"
+       id="path7507"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 764.20927,824.5901 0.27285,11.2482"
+       id="path7509"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 764.48212,835.8383 9.87765,5.3878"
+       id="path7511"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 774.35977,841.2261 9.60481,-5.8604"
+       id="path7513"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 837.86645,817.5763 13.8189,0"
+       id="path7515"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 851.68535,817.5763 0,-24.8031"
+       id="path7517"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 851.68535,792.7732 -13.8189,0"
+       id="path7519"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 837.86645,792.7732 0,24.8031"
+       id="path7521"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 837.86645,870.7259 13.8189,0"
+       id="path7523"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 851.68535,870.7259 0,-24.8031"
+       id="path7525"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 851.68535,845.9228 -13.8189,0"
+       id="path7527"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 837.86645,845.9228 0,24.8031"
+       id="path7529"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 799.66341,845.53239 37.58245,37.5825"
+       parametric:d="`M ${794.65242+((size*mm) * 0.353553391)},${850.54338-((size*mm) * 0.353553391)} ${832.23487+((size*mm) * 0.353553391)},${888.12588-((size*mm) * 0.353553391)}`"
+       id="path7535"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 789.64143,804.40139 37.58245,-37.58242"
+       parametric:d="`M ${794.65242-((size*mm) * 0.353553391)},${809.41238-((size*mm) * 0.353553391)} ${832.23487-((size*mm) * 0.353553391)},${771.82996-((size*mm) * 0.353553391)}`"
+       id="path7537"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 748.51043,845.53239 -37.58244,37.5825"
+       parametric:d="`M ${753.52142-((size*mm) * 0.353553391)},${850.54338-((size*mm) * 0.353553391)} ${715.93898-((size*mm) * 0.353553391)},${888.12588-((size*mm) * 0.353553391)}`"
+       id="path7541"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 758.53241,804.40139 720.94997,766.81897"
+       parametric:d="`M ${753.52142+((size*mm) * 0.353553391)},${809.41238-((size*mm) * 0.353553391)} ${715.93898+((size*mm) * 0.353553391)},${771.82996-((size*mm) * 0.353553391)}`"
+       id="path7543"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 897.46487,930.158 0,-44.3075"
+       id="path7547"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 991.06207,1023.731 28.00523,28.0053"
+       id="path7549"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 557.11177,1023.731 -28.00527,28.0053"
+       id="path7551"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 901.00818,724.8115 5.62046,0"
+       id="path7553"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 897.46487,728.3548 0,48.58513"
+       id="path7555"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 904.18768,780.4832 -3.1795,0"
+       id="path7557"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 647.87432,883.0159 -4.96063,0"
+       id="path7559"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 640.07905,885.8505 0,44.3075"
+       id="path7561"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 642.91369,932.9927 4.96063,0"
+       id="path7563"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 650.70897,930.158 0,-44.3075"
+       id="path7565"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 643.98616,780.4832 3.1795,0"
+       id="path7567"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 650.70897,728.3548 0,48.58513"
+       id="path7569"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 647.16566,724.8115 -5.62046,0"
+       id="path7571"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 789.64143,855.55437 10.02198,-10.02198"
+       parametric:d="`M ${794.65242-((size*mm) * 0.353553391)},${850.54338+((size*mm) * 0.353553391)} ${794.65242+((size*mm) * 0.353553391)},${850.54338-((size*mm) * 0.353553391)}`"
+       id="path7617"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 789.64143,855.55437 37.58245,37.5825"
+       parametric:d="`M ${794.65242-((size*mm) * 0.353553391)},${850.54338+((size*mm) * 0.353553391)} ${832.23487-((size*mm) * 0.353553391)},${888.12588+((size*mm) * 0.353553391)}`"
+       id="path7619"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 827.22388,893.13687 10.02198,-10.02198"
+       parametric:d="`M ${832.23487-((size*mm) * 0.353553391)},${888.12588+((size*mm) * 0.353553391)} ${832.23487+((size*mm) * 0.353553391)},${888.12588-((size*mm) * 0.353553391)}`"
+       id="path7621"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 799.66341,814.42337 789.64143,804.40139"
+       parametric:d="`M ${794.65242+((size*mm) * 0.353553391)},${809.41238+((size*mm) * 0.353553391)} ${794.65242-((size*mm) * 0.353553391)},${809.41238-((size*mm) * 0.353553391)}`"
+       id="path7623"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 799.66341,814.42337 37.58245,-37.58242"
+       parametric:d="`M ${794.65242+((size*mm) * 0.353553391)},${809.41238+((size*mm) * 0.353553391)} ${832.23487+((size*mm) * 0.353553391)},${771.82996+((size*mm) * 0.353553391)}`"
+       id="path7625"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 837.24586,776.84095 827.22388,766.81897"
+       parametric:d="`M ${832.23487+((size*mm) * 0.353553391)},${771.82996+((size*mm) * 0.353553391)} ${832.23487-((size*mm) * 0.353553391)},${771.82996-((size*mm) * 0.353553391)}`"
+       id="path7627"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 720.94997,893.13687 710.92799,883.11489"
+       parametric:d="`M ${715.93898+((size*mm) * 0.353553391)},${888.12588+((size*mm) * 0.353553391)} ${715.93898-((size*mm) * 0.353553391)},${888.12588-((size*mm) * 0.353553391)}`"
+       id="path7651"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 758.53241,855.55437 -37.58244,37.5825"
+       parametric:d="`M ${753.52142+((size*mm) * 0.353553391)},${850.54338+((size*mm) * 0.353553391)} ${715.93898+((size*mm) * 0.353553391)},${888.12588+((size*mm) * 0.353553391)}`"
+       id="path7653"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 758.53241,855.55437 748.51043,845.53239"
+       parametric:d="`M ${753.52142+((size*mm) * 0.353553391)},${850.54338+((size*mm) * 0.353553391)} ${753.52142-((size*mm) * 0.353553391)},${850.54338-((size*mm) * 0.353553391)}`"
+       id="path7655"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 710.92799,776.84095 10.02198,-10.02198"
+       parametric:d="`M ${715.93898-((size*mm) * 0.353553391)},${771.82996+((size*mm) * 0.353553391)} ${715.93898+((size*mm) * 0.353553391)},${771.82996-((size*mm) * 0.353553391)}`"
+       id="path7657"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 748.51043,814.42337 710.92799,776.84095"
+       parametric:d="`M ${753.52142-((size*mm) * 0.353553391)},${809.41238+((size*mm) * 0.353553391)} ${715.93898-((size*mm) * 0.353553391)},${771.82996+((size*mm) * 0.353553391)}`"
+       id="path7659"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 748.51043,814.42337 10.02198,-10.02198"
+       parametric:d="`M ${753.52142-((size*mm) * 0.353553391)},${809.41238+((size*mm) * 0.353553391)} ${753.52142+((size*mm) * 0.353553391)},${809.41238-((size*mm) * 0.353553391)}`"
+       id="path7661"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 849.96915,1036.2662 -151.76446,0"
+       id="path7685"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 905.26015,932.9927 -4.96063,0"
+       id="path7687"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 908.09479,885.8505 0,44.3075"
+       id="path7689"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 900.29952,883.0159 4.96063,0"
+       id="path7691"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 815.46136,929.1581 -82.74887,0"
+       id="path7693"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 681.98309,976.9521 727.7015,931.2337"
+       id="path7695"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 689.49958,995.0985 169.17469,0"
+       id="path7697"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 866.19076,976.9521 820.47235,931.2337"
+       id="path7699"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 702.74612,850.5835 a 3.543307,3.543307 0 0 0 1.11246,-2.578"
+       id="path7701"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 703.85858,815.9283 a 3.543307,3.543307 0 0 0 -1.03781,-2.5055"
+       id="path7703"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 695.72215,806.3242 a 3.543307,3.543307 0 0 0 -2.5055,-1.0378"
+       id="path7705"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 679.05543,805.2864 a 3.543307,3.543307 0 0 0 -3.54331,3.5433"
+       id="path7707"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 675.51212,854.8927 a 3.543307,3.543307 0 0 0 3.54331,3.5433"
+       id="path7709"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 693.01129,858.436 a 3.543307,3.543307 0 0 0 2.43085,-0.9653"
+       id="path7711"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 820.47235,931.2337 a 7.086614,7.086614 0 0 0 -5.01099,-2.0756"
+       id="path7713"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 673.37894,706.00635 a 191.70221,191.70221 0 0 0 201.41596,0"
+       id="path7715"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 910.11019,729.01346 a 3.543307,3.543307 0 0 0 -3.48155,-4.20196"
+       id="path7717"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 650.70897,885.8505 a 2.834646,2.834646 0 0 0 -2.83465,-2.8346"
+       id="path7719"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 640.45613,776.63354 a 174.84443,174.84443 0 0 0 -2.39248,-47.62008"
+       id="path7721"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 850.57619,1039.7023 a 1.771654,1.771654 0 0 0 -0.60704,-3.4361"
+       id="path7723"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 874.7949,706.00635 A 355.21654,355.21654 0 0 0 1000.3851,573.19798"
+       id="path7725"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1000.3851,573.19798 a 17.716535,17.716535 0 0 0 1.5812,-12.88697"
+       id="path7727"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1078.9344,600.18528 a 58.218996,58.218996 0 1 0 -76.9681,-39.87427"
+       id="path7729"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1078.9344,600.18528 a 35.433071,35.433071 0 0 0 -16.7566,13.20934"
+       id="path7731"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 979.07281,718.72032 a 428.74016,428.74016 0 0 0 83.10499,-105.3257"
+       id="path7733"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 979.07281,718.72032 A 177.16535,177.16535 0 0 0 928.23414,802.6863"
+       id="path7735"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 928.23414,802.6863 A 222.00081,222.00081 0 0 0 928.05295,917.758"
+       id="path7737"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 928.05295,917.758 a 250.17122,250.17122 0 0 0 63.00912,105.973"
+       id="path7739"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1019.0673,1051.7363 a 26.55216,26.55216 0 0 0 18.8308,7.7769"
+       id="path7741"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1003.3612,1133.9417 a 58.399827,58.399827 0 1 0 34.5369,-74.4285"
+       id="path7743"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1003.3612,1133.9417 a 54.486732,54.486732 0 0 0 -14.29781,-28.3742"
+       id="path7745"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 989.06339,1105.5675 A 157.56213,157.56213 0 0 0 845.81661,1059.6061"
+       id="path7747"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 702.35723,1059.6061 a 240.57066,240.57066 0 0 0 143.45938,0"
+       id="path7749"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 702.35723,1059.6061 a 157.56213,157.56213 0 0 0 -143.24678,45.9614"
+       id="path7751"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 559.11045,1105.5675 a 54.486732,54.486732 0 0 0 -14.29779,28.3742"
+       id="path7753"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 510.27574,1059.5132 a 58.399827,58.399827 0 1 0 34.53692,74.4285"
+       id="path7755"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 510.27574,1059.5132 a 26.55216,26.55216 0 0 0 18.83076,-7.7769"
+       id="path7757"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 557.11177,1023.731 A 250.17122,250.17122 0 0 0 620.12089,917.758"
+       id="path7759"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 620.12089,917.758 A 222.00081,222.00081 0 0 0 619.9397,802.6863"
+       id="path7761"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 619.9397,802.6863 A 177.16535,177.16535 0 0 0 569.10103,718.72032"
+       id="path7763"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 485.99608,613.39462 a 428.74016,428.74016 0 0 0 83.10495,105.3257"
+       id="path7765"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 485.99608,613.39462 A 35.433071,35.433071 0 0 0 469.23946,600.18528"
+       id="path7767"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 546.20751,560.31101 a 58.218996,58.218996 0 1 0 -76.96805,39.87427"
+       id="path7769"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 546.20751,560.31101 a 17.716535,17.716535 0 0 0 1.58123,12.88697"
+       id="path7771"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 547.78874,573.19798 a 355.21654,355.21654 0 0 0 125.5902,132.80837"
+       id="path7773"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 901.00818,724.8115 a 3.543307,3.543307 0 0 0 -3.54331,3.5433"
+       id="path7775"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 897.46487,776.93993 a 3.543307,3.543307 0 0 0 3.54331,3.54327"
+       id="path7777"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 904.18768,780.4832 a 3.543307,3.543307 0 0 0 3.53003,-3.84966"
+       id="path7779"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 910.11019,729.01346 a 174.84443,174.84443 0 0 0 -2.39248,47.62008"
+       id="path7781"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 642.91369,883.0159 a 2.834646,2.834646 0 0 0 -2.83464,2.8346"
+       id="path7783"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 640.07905,930.158 a 2.834646,2.834646 0 0 0 2.83464,2.8347"
+       id="path7785"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 647.87432,932.9927 a 2.834646,2.834646 0 0 0 2.83465,-2.8347"
+       id="path7787"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 640.45613,776.63354 a 3.543307,3.543307 0 0 0 3.53003,3.84966"
+       id="path7789"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 647.16566,780.4832 a 3.543307,3.543307 0 0 0 3.54331,-3.54327"
+       id="path7791"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 650.70897,728.3548 a 3.543307,3.543307 0 0 0 -3.54331,-3.5433"
+       id="path7793"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 641.5452,724.8115 a 3.543307,3.543307 0 0 0 -3.48155,4.20196"
+       id="path7795"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 698.20469,1036.2662 a 1.771654,1.771654 0 0 0 -0.60703,3.4361"
+       id="path7797"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 697.59766,1039.7023 a 223.23737,223.23737 0 0 0 152.97853,0"
+       id="path7799"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 897.46487,930.158 a 2.834646,2.834646 0 0 0 2.83465,2.8347"
+       id="path7801"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 905.26015,932.9927 a 2.834646,2.834646 0 0 0 2.83464,-2.8347"
+       id="path7803"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 908.09479,885.8505 a 2.834646,2.834646 0 0 0 -2.83464,-2.8346"
+       id="path7805"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 900.29952,883.0159 a 2.834646,2.834646 0 0 0 -2.83465,2.8346"
+       id="path7807"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 732.71249,929.1581 a 7.086614,7.086614 0 0 0 -5.01099,2.0756"
+       id="path7809"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 681.98309,976.9521 a 10.629921,10.629921 0 0 0 7.51649,18.1464"
+       id="path7811"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 858.67427,995.0985 a 10.629921,10.629921 0 0 0 7.51649,-18.1464"
+       id="path7813"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="translate(315.54562,-695.99146)"
+     id="unio central">
+    <path
+       d="m 137.74534,770.15937 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 0 0 10.62992,0 z"
+       id="path7840"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 139.51719,797.47177 -3.9e-4,18.8051"
+       parametric:d="`M ${132.430575+((size*mm)/2)},797.47177 ${132.430185+((size*mm)/2)},816.27687`"
+       id="path7842"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 125.34396,797.47177 14.17323,0"
+       parametric:d="`M ${132.430575-((size*mm)/2)},797.47177 ${132.430575+((size*mm)/2)},797.47177`"
+       id="path7844"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 125.34396,816.31147 0,-18.8397"
+       parametric:d="`M ${132.430575-((size*mm)/2)},816.31147 ${132.430575-((size*mm)/2)},797.47177`"
+       id="path7846"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 105.11802,777.24613 -18.839705,0"
+       parametric:d="`M 105.11802,${770.159515+((size*mm)/2)} 86.278315,${770.159515+((size*mm)/2)}`"
+       id="path7848"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 105.11802,763.0729 0,14.17323"
+       parametric:d="`M 105.11802,${770.159515-((size*mm)/2)} 105.11802,${770.159515+((size*mm)/2)}`"
+       id="path7850"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 86.278257,763.0729 18.839763,0"
+       parametric:d="`M 86.278257,${770.159515-((size*mm)/2)} 105.11802,${770.159515-((size*mm)/2)}`"
+       id="path7852"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 125.34357,742.84707 0,-18.8398"
+       parametric:d="`M ${132.430185-((size*mm)/2)},742.84707 ${132.430185-((size*mm)/2)},724.00727`"
+       id="path7854"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 139.5168,742.84707 -14.17323,0"
+       parametric:d="`M ${132.430185+((size*mm)/2)},742.84707 ${132.430185-((size*mm)/2)},742.84707`"
+       id="path7856"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 139.5168,724.00727 0,18.8398"
+       parametric:d="`M ${132.430185+((size*mm)/2)},724.00727 ${132.430185+((size*mm)/2)},742.84707`"
+       id="path7858"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 159.74273,763.07261 18.83971,0"
+       parametric:d="`M 159.74273,${770.159225-((size*mm)/2)} 178.58244,${770.159225-((size*mm)/2)}`"
+       id="path7860"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 159.74273,777.24584 0,-14.17323"
+       parametric:d="`M 159.74273,${770.159225+((size*mm)/2)} 159.74273,${770.159225-((size*mm)/2)}`"
+       id="path7862"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 178.58244,777.24584 -18.83971,0"
+       parametric:d="`M 178.58244,${770.159225+((size*mm)/2)} 159.74273,${770.159225+((size*mm)/2)}`"
+       id="path7864"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 112.27896,812.25067 a 46.666434,46.666434 0 0 0 13.065,4.0608"
+       parametric:d="`M 112.27896,812.25067 A 46.666434,46.666434 0 0 0 ${132.430575-((size*mm)/2)},816.31147`"
+       id="path7866"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 112.27896,812.25067 A 40.208069,40.208069 0 0 0 90.33909,790.31077"
+       id="path7868"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 89.946877,750.84857 a 46.666434,46.666434 0 0 0 -3.66862,12.22433"
+       parametric:d="`M 89.946877,750.84857 A 46.666434,46.666434 0 0 0 86.278257,${770.159515-((size*mm)/2)}`"
+       id="path7870"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 89.946877,750.84857 a 40.062542,40.062542 0 0 0 23.172283,-23.1725"
+       id="path7872"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 152.57618,728.06537 a 46.666434,46.666434 0 0 0 -13.05938,-4.0581"
+       parametric:d="`M 152.57618,728.06537 A 46.666434,46.666434 0 0 0 ${132.430185+((size*mm)/2)},724.00727`"
+       id="path7874"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 152.57618,728.06537 a 40.20805,40.20805 0 0 0 21.94549,21.9426"
+       id="path7876"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 174.42645,790.42997 a 46.632232,46.632232 0 0 0 4.15599,-13.18413"
+       parametric:d="`M 174.42645,790.42997 A 46.632232,46.632232 0 0 0 178.58244,${770.159225+((size*mm)/2)}`"
+       id="path7878"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 174.42645,790.42997 a 40.062542,40.062542 0 0 0 -21.71471,21.7203"
+       id="path7880"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 125.34357,724.00727 a 46.666434,46.666434 0 0 0 -12.22441,3.6688"
+       parametric:d="`M ${132.430185-((size*mm)/2)},724.00727 A 46.666434,46.666434 0 0 0 113.11916,727.67607`"
+       id="path7882"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 178.58244,763.07261 a 46.666434,46.666434 0 0 0 -4.06077,-13.06464"
+       parametric:d="`M 178.58244,${770.159225-((size*mm)/2)} A 46.666434,46.666434 0 0 0 174.52167,750.00797`"
+       id="path7884"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 86.278315,777.24613 a 46.666434,46.666434 0 0 0 4.060775,13.06464"
+       parametric:d="`M 86.278315,${770.159515+((size*mm)/2)} A 46.666434,46.666434 0 0 0 90.33909,790.31077`"
+       id="path7886"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 139.5168,816.27687 a 46.632232,46.632232 0 0 0 13.19494,-4.1266"
+       parametric:d="`M ${132.430185+((size*mm)/2)},816.27687 A 46.632232,46.632232 0 0 0 152.71174,812.15027`"
+       id="path7888"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="matrix(0,1,-1,0,244.01523,1132.4223)"
+     id="pota1">
+    <path
+       d="m -253.20057,7.4413864 c -0.61992,4.7907996 -9.21439,39.8168996 -24.8802,56.6818996 -17.04007,18.3444 -42.44654,15.2018 -53.56487,14.0337"
+       id="path7915"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -380.21114,12.731886 c 3.71433,-12.91229964 20.93259,-46.933797 20.99894,-66.880027 0.0707,-21.25654 -19.33797,-26.52788 -26.54199,-26.52788"
+       id="path7917"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -294.97858,43.339686 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+       id="path7919"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -313.43679,-84.219331 a 1.771655,1.771655 0 1 0 -3.54331,0 1.771655,1.771655 0 0 0 3.54331,0 z"
+       id="path7921"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -199.20057,-88.825629 -14.17323,0"
+       parametric:d="`M -199.20057,${ -102.99886 + (size*mm)} -213.3738,${ -102.99886 + (size*mm)}`"
+       id="path7923"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -199.20057,-94.849249 0,6.02362"
+       parametric:d="`M -199.20057,${ -109.02248 + (size*mm)} -199.20057,${ -102.99886 + (size*mm)}`"
+       id="path7925"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -213.3738,-94.849249 14.17323,0"
+       parametric:d="`M -213.3738,${ -109.02248 + (size*mm)} -199.20057,${ -109.02248 + (size*mm)}`"
+       id="path7927"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -213.3738,-88.825629 0,-6.02362"
+       parametric:d="`M -213.3738,${ -102.99886 + (size*mm)} -213.3738,${ -109.02248 + (size*mm)}`"
+       id="path7929"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -145.16514,110.66259 0,-113.3859036"
+       id="path7931"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -213.3738,-20.439814 -27.39218,0"
+       id="path7933"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -240.76598,-20.439814 0,1.8248"
+       id="path7935"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -247.8526,-11.528414 -3.71657,0"
+       id="path7937"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -266.20946,-0.85671364 5.7154,0"
+       id="path7939"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -352.41317,47.009886 0,-2.3673"
+       id="path7941"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -347.75032,37.983286 23.6836,-8.6201"
+       id="path7943"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -324.06672,29.363186 0,-9.0966"
+       id="path7945"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -324.06672,20.266586 -21.21367,7.7211"
+       id="path7947"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -352.41317,22.993286 0,-8"
+       id="path7949"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -352.41317,14.993286 -26.09536,0"
+       id="path7951"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -385.75419,-80.676021 -61.30173,0"
+       id="path7953"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -473.56868,-93.431931 -18.80512,0"
+       id="path7955"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -492.3738,-93.431931 0,-15.590549"
+       id="path7957"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -492.3738,-109.02248 3.54331,0"
+       id="path7959"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -488.83049,-109.02248 0,-14.17323"
+       parametric:d="`M -488.83049,-109.02248 -488.83049,${-109.02248-(size*mm)}`"
+       id="path7961"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -488.83049,-123.19571 53.1496,0"
+       parametric:d="`M -488.83049,${-109.02248-(size*mm)} -435.68089,${-109.02248-(size*mm)}`"
+       id="path7963"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -435.68089,-123.19571 0,14.17323"
+       parametric:d="`M -435.68089,${-109.02248-(size*mm)} -435.68089,-109.02248`"
+       id="path7965"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -435.68089,-109.02248 293.17323,0"
+       id="path7967"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -142.50766,-109.02248 0,-14.17323"
+       parametric:d="`M -142.50766,-109.02248 -142.50766,${-109.02248-(size*mm)}`"
+       id="path7969"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -123.01947,-123.19571 0,53.503939"
+       parametric:d="`M ${-115.932855-((size*mm)/2)},${-109.02248-(size*mm)} ${-115.932855-((size*mm)/2)},-69.691771`"
+       id="path7971"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -123.01947,-69.691771 14.17323,0"
+       parametric:d="`M ${-115.932855-((size*mm)/2)},-69.691771 ${-115.932855+((size*mm)/2)},-69.691771`"
+       id="path7973"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -108.84624,-69.691771 0,-53.503939"
+       parametric:d="`M ${-115.932855+((size*mm)/2)},-69.691771 ${-115.932855+((size*mm)/2)},${-109.02248-(size*mm)}`"
+       id="path7975"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -108.84624,-123.19571 19.488185,0"
+       parametric:d="`M ${-115.932855+((size*mm)/2)},${-109.02248-(size*mm)} -89.358055,${-109.02248-(size*mm)}`"
+       id="path7977"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -89.358055,-123.19571 0,14.17323"
+       parametric:d="`M -89.358055,${-109.02248-(size*mm)} -89.358055,-109.02248`"
+       id="path7979"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -89.358055,-109.02248 14.17322,0"
+       id="path7981"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -75.184835,-109.02248 0,15.678299"
+       id="path7983"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -84.928925,-41.699611 0,152.362201"
+       id="path7985"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -95.558845,121.29249 -38.976375,0"
+       id="path7987"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -142.50766,-123.19571 19.48819,0"
+       parametric:d="`M -142.50766,${-109.02248-(size*mm)} ${-115.932855-((size*mm)/2)},${-109.02248-(size*mm)}`"
+       id="path7989"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -162.88167,-20.439814 -36.3189,0"
+       id="path7991"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -145.16514,110.66259 a 10.629921,10.629921 0 0 0 10.62992,10.6299"
+       id="path7993"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M -145.16514,-2.7233136 A 17.716535,17.716535 0 0 0 -162.88167,-20.439814"
+       id="path7995"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -199.20057,-20.439814 a 7.854253,7.854253 0 0 0 -14.17323,0"
+       id="path7997"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -247.8526,-11.528414 a 7.086614,7.086614 0 0 0 7.08662,-7.0866"
+       id="path7999"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -251.56917,-11.528414 a 10.519727,10.519727 0 0 0 -12.90111,6.6658004"
+       id="path8001"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -264.47028,-4.8626136 a 11.513773,11.513773 0 0 0 -1.73918,4.00589996"
+       id="path8003"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -253.20057,7.4413864 a 7.354298,7.354298 0 0 0 -7.29349,-8.29810004"
+       id="path8005"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -343.35743,71.935686 a 17.716535,17.716535 0 0 0 11.71179,6.2213"
+       id="path8007"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -352.41317,47.009886 a 38.626423,38.626423 0 0 0 9.05574,24.9258"
+       id="path8009"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -352.41317,22.993286 a 5.314961,5.314961 0 0 0 7.13278,4.9944"
+       id="path8011"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -380.21114,12.731886 a 1.771654,1.771654 0 0 0 1.70261,2.2614"
+       id="path8013"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -459.72544,-86.771621 a 16.214404,16.214404 0 0 0 12.66952,6.0956"
+       id="path8015"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -459.72544,-86.771621 a 17.716535,17.716535 0 0 0 -13.84324,-6.66031"
+       id="path8017"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -75.184835,-93.344181 a 141.73228,141.73228 0 0 0 -9.74409,51.64457"
+       id="path8019"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -95.558845,121.29249 a 10.629921,10.629921 0 0 0 10.62992,-10.6299"
+       id="path8021"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -347.75032,37.983286 a 7.086614,7.086614 0 0 0 -4.66285,6.6593"
+       id="path8023"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="pota2">
+    <path
+       d="m 138.34776,276.89976 c 4.7908,0.61992 39.8169,9.21439 56.6819,24.8802 18.3444,17.04007 15.2018,42.44654 14.0337,53.56487"
+       id="path7915-6"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 143.63826,403.91033 C 130.72596,400.196 96.70446,382.97774 76.75823,382.91139 55.50169,382.84069 50.23035,402.24936 50.23035,409.45338"
+       id="path7917-6"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 174.24606,318.67777 a 5.314961,5.314961 0 1 0 0,10.62992 5.314961,5.314961 0 1 0 0,-10.62992 z"
+       id="path7919-8"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 46.68704,337.13598 a 1.771655,1.771655 0 1 0 0,3.54331 1.771655,1.771655 0 0 0 0,-3.54331 z"
+       id="path7921-3"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 42.080741,222.89976 0,14.17323"
+       parametric:d="`M ${27.90751 + (size*mm)},222.89976 ${27.90751 + (size*mm)},237.07299`"
+       id="path7923-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 36.057121,222.89976 6.02362,0"
+       parametric:d="`M ${21.88389 + (size*mm)},222.89976 ${27.90751 + (size*mm)},222.89976`"
+       id="path7925-6"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 36.057121,237.07299 0,-14.17323"
+       parametric:d="`M ${21.88389 + (size*mm)},237.07299 ${21.88389 + (size*mm)},222.89976`"
+       id="path7927-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 42.080741,237.07299 -6.02362,0"
+       parametric:d="`M ${27.90751 + (size*mm)},237.07299 ${21.88389 + (size*mm)},237.07299`"
+       id="path7929-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 241.56896,168.86433 -113.3859,0"
+       id="path7931-6"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 110.46656,237.07299 0,27.39218"
+       id="path7933-7"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 110.46656,264.46517 1.8248,0"
+       id="path7935-8"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 119.37796,271.55179 0,3.71657"
+       id="path7937-8"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 130.04966,289.90865 0,-5.7154"
+       id="path7939-5"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 177.91626,376.11236 -2.3673,0"
+       id="path7941-3"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 168.88966,371.44951 -8.6201,-23.6836"
+       id="path7943-8"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 160.26956,347.76591 -9.0966,0"
+       id="path7945-3"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 151.17296,347.76591 7.7211,21.21367"
+       id="path7947-6"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 153.89966,376.11236 -8,0"
+       id="path7949-7"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 145.89966,376.11236 0,26.09536"
+       id="path7951-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 50.23035,409.45338 0,61.30173"
+       id="path7953-8"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 37.47444,497.26787 0,18.80512"
+       id="path7955-2"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 37.47444,516.07299 -15.59055,0"
+       id="path7957-3"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 21.88389,516.07299 0,-3.54331"
+       id="path7959-8"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 21.88389,512.52968 -14.1732308,0"
+       parametric:d="`M 21.88389,512.52968 ${21.88389-(size*mm)},512.52968`"
+       id="path7961-0"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 7.7106592,512.52968 0,-53.1496"
+       parametric:d="`M ${21.88389-(size*mm)},512.52968 ${21.88389-(size*mm)},459.38008`"
+       id="path7963-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 7.7106592,459.38008 14.1732308,0"
+       parametric:d="`M ${21.88389-(size*mm)},459.38008 21.88389,459.38008`"
+       id="path7965-8"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 21.88389,459.38008 0,-293.17323"
+       id="path7967-8"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 21.88389,166.20685 -14.1732308,0"
+       parametric:d="`M 21.88389,166.20685 ${21.88389-(size*mm)},166.20685`"
+       id="path7969-3"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 7.7106592,146.71866 53.5039408,0"
+       parametric:d="`M ${21.88389-(size*mm)},${139.632045+((size*mm)/2)} 61.2146,${139.632045+((size*mm)/2)}`"
+       id="path7971-8"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 61.2146,146.71866 0,-14.17323"
+       parametric:d="`M 61.2146,${139.632045+((size*mm)/2)} 61.2146,${139.632045-((size*mm)/2)}`"
+       id="path7973-8"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 61.2146,132.54543 -53.5039408,0"
+       parametric:d="`M 61.2146,${139.632045-((size*mm)/2)} ${21.88389-(size*mm)},${139.632045-((size*mm)/2)}`"
+       id="path7975-7"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 7.7106592,132.54543 0,-19.48819"
+       parametric:d="`M ${21.88389-(size*mm)},${139.632045-((size*mm)/2)} ${21.88389-(size*mm)},113.05724`"
+       id="path7977-4"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 7.7106592,113.05724 14.1732308,0"
+       parametric:d="`M ${21.88389-(size*mm)},113.05724 21.88389,113.05724`"
+       id="path7979-5"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 21.88389,113.05724 0,-14.173219"
+       id="path7981-7"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 21.88389,98.884021 15.6783,0"
+       id="path7983-9"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 89.20676,108.62811 152.3622,0"
+       id="path7985-8"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 252.19886,119.25803 0,38.97638"
+       id="path7987-4"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 7.7106592,166.20685 0,-19.48819"
+       parametric:d="`M ${21.88389-(size*mm)},166.20685 ${21.88389-(size*mm)},${139.632045+((size*mm)/2)}`"
+       id="path7989-2"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 110.46656,186.58086 0,36.3189"
+       id="path7991-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 241.56896,168.86433 a 10.629921,10.629921 0 0 0 10.6299,-10.62992"
+       id="path7993-2"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 128.18306,168.86433 a 17.716535,17.716535 0 0 0 -17.7165,17.71653"
+       id="path7995-9"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 110.46656,222.89976 a 7.854253,7.854253 0 0 0 0,14.17323"
+       id="path7997-9"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 119.37796,271.55179 a 7.086614,7.086614 0 0 0 -7.0866,-7.08662"
+       id="path7999-0"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 119.37796,275.26836 a 10.519727,10.519727 0 0 0 6.6658,12.90111"
+       id="path8001-4"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 126.04376,288.16947 a 11.513773,11.513773 0 0 0 4.0059,1.73918"
+       id="path8003-3"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 138.34776,276.89976 a 7.354298,7.354298 0 0 0 -8.2981,7.29349"
+       id="path8005-0"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 202.84206,367.05662 a 17.716535,17.716535 0 0 0 6.2213,-11.71179"
+       id="path8007-8"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 177.91626,376.11236 a 38.626423,38.626423 0 0 0 24.9258,-9.05574"
+       id="path8009-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 153.89966,376.11236 a 5.314961,5.314961 0 0 0 4.9944,-7.13278"
+       id="path8011-7"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 143.63826,403.91033 a 1.771654,1.771654 0 0 0 2.2614,-1.70261"
+       id="path8013-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 44.13475,483.42463 a 16.214404,16.214404 0 0 0 6.0956,-12.66952"
+       id="path8015-9"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 44.13475,483.42463 a 17.716535,17.716535 0 0 0 -6.66031,13.84324"
+       id="path8017-0"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 37.56219,98.884021 a 141.73228,141.73228 0 0 0 51.64457,9.744089"
+       id="path8019-4"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 252.19886,119.25803 a 10.629921,10.629921 0 0 0 -10.6299,-10.62992"
+       id="path8021-7"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 168.88966,371.44951 a 7.086614,7.086614 0 0 0 6.6593,4.66285"
+       id="path8023-2"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="translate(100.26405,710.51567)"
+     id="base inferior">
+    <path
+       d="m 631.7382,-305.92027 a 12.401575,12.401575 0 1 0 -24.80315,0 12.401575,12.401575 0 1 0 24.80315,0 z"
+       id="path8050"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 719.69424,-375.01476 0,3.54331"
+       id="path8052"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 723.23754,-367.92815 48.62486,0"
+       id="path8054"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 773.68542,-368.43309 3.10101,-7.6908"
+       id="path8056"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 775.14332,-378.55807 -51.90578,0"
+       id="path8058"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 756.4052,-451.75809 731.97912,-427.332"
+       parametric:d="`M ${761.41619-((size*mm) * 0.353553391)},${-446.7471-((size*mm) * 0.353553391)} ${736.99011-((size*mm) * 0.353553391)},${-422.32101-((size*mm) * 0.353553391)}`"
+       id="path8060"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 731.97912,-427.332 10.02198,10.02198"
+       parametric:d="`M ${736.99011-((size*mm) * 0.353553391)},${-422.32101-((size*mm) * 0.353553391)} ${736.99011+((size*mm) * 0.353553391)},${-422.32101+((size*mm) * 0.353553391)}`"
+       id="path8062"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 742.0011,-417.31002 24.42608,-24.42609"
+       parametric:d="`M ${736.99011+((size*mm) * 0.353553391)},${-422.32101+((size*mm) * 0.353553391)} ${761.41619+((size*mm) * 0.353553391)},${-446.7471+((size*mm) * 0.353553391)}`"
+       id="path8064"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 765.21769,-168.85167 -24.46934,-24.42611"
+       parametric:d="`M ${760.2067+((size*mm) * 0.353553391)},${-163.84068-((size*mm) * 0.353553391)} ${735.73736+((size*mm) * 0.353553391)},${-188.266786-((size*mm) * 0.353553391)}`"
+       id="path8066"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 740.74835,-193.27778 -10.02198,10.02199"
+       parametric:d="`M ${735.73736+((size*mm) * 0.353553391)},${-188.266786-((size*mm) * 0.353553391)} ${735.73736-((size*mm) * 0.353553391)},${-188.266786+((size*mm) * 0.353553391)}`"
+       id="path8068"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 730.72637,-183.25579 24.46934,24.4261"
+       parametric:d="`M ${735.73736-((size*mm) * 0.353553391)},${-188.266786+((size*mm) * 0.353553391)} ${760.2067-((size*mm) * 0.353553391)},${-163.84068+((size*mm) * 0.353553391)}`"
+       id="path8070"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 482.22478,-160.03919 24.46935,-24.4694"
+       parametric:d="`M ${477.21379+((size*mm) * 0.353553391)},${-165.05018+((size*mm) * 0.353553391)} ${501.68314+((size*mm) * 0.353553391)},${-189.51958+((size*mm) * 0.353553391)}`"
+       id="path8072"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 506.69413,-184.50859 -10.02198,-10.02198"
+       parametric:d="`M ${501.68314+((size*mm) * 0.353553391)},${-189.51958+((size*mm) * 0.353553391)} ${501.68314-((size*mm) * 0.353553391)},${-189.51958-((size*mm) * 0.353553391)}`"
+       id="path8074"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 496.67215,-194.53057 -24.46935,24.4694"
+       parametric:d="`M ${501.68314-((size*mm) * 0.353553391)},${-189.51958-((size*mm) * 0.353553391)} ${477.21379-((size*mm) * 0.353553391)},${-165.05018-((size*mm) * 0.353553391)}`"
+       id="path8076"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 473.49881,-443.03212 24.42609,24.46935"
+       parametric:d="`M ${478.5098-((size*mm) * 0.353553391)},${-448.04311+((size*mm) * 0.353553391)} ${502.93589-((size*mm) * 0.353553391)},${-423.57376+((size*mm) * 0.353553391)}`"
+       id="path8078"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 497.9249,-418.56277 10.02198,-10.02198"
+       parametric:d="`M ${502.93589-((size*mm) * 0.353553391)},${-423.57376+((size*mm) * 0.353553391)} ${502.93589+((size*mm) * 0.353553391)},${-423.57376-((size*mm) * 0.353553391)}`"
+       id="path8080"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 507.94688,-428.58475 483.52079,-453.0541"
+       parametric:d="`M ${502.93589+((size*mm) * 0.353553391)},${-423.57376-((size*mm) * 0.353553391)} ${478.5098+((size*mm) * 0.353553391)},${-448.04311-((size*mm) * 0.353553391)}`"
+       id="path8082"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 771.8624,-243.91236 -48.62486,0"
+       id="path8084"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 719.69424,-240.36906 0,3.5433"
+       id="path8086"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 723.23754,-233.28246 51.90578,0"
+       id="path8088"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 776.78643,-235.71666 -3.10101,-7.6908"
+       id="path8090"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 518.97901,-236.82576 0,-3.5433"
+       id="path8092"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 515.4357,-243.91236 -48.62486,0"
+       id="path8094"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 464.98783,-243.40746 -3.10102,7.6908"
+       id="path8096"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 463.52993,-233.28246 51.90577,0"
+       id="path8098"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 466.81084,-367.92815 48.62486,0"
+       id="path8100"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 518.97901,-371.47145 0,-3.54331"
+       id="path8102"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 515.4357,-378.55807 -51.90577,0"
+       id="path8104"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 461.88681,-376.12389 3.10102,7.6908"
+       id="path8106"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 697.80114,-161.87086 -159.44882,0"
+       id="path8108"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 719.69424,-371.47145 a 3.543307,3.543307 0 0 0 3.5433,3.5433"
+       id="path8110"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 771.8624,-367.92815 a 3.543307,3.543307 0 0 0 1.82302,-0.50494"
+       id="path8112"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 776.78643,-376.12389 a 1.771654,1.771654 0 0 0 -1.64311,-2.43418"
+       id="path8114"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 723.23754,-378.55807 a 3.543307,3.543307 0 0 0 -3.5433,3.54331"
+       id="path8116"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 802.49861,-386.73156 a 12.274894,12.274894 0 0 0 -5.31963,11.61553"
+       id="path8118"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 787.14797,-352.20062 a 23.835162,23.835162 0 0 0 10.03101,-22.91541"
+       id="path8120"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 787.14797,-352.20062 a 50.383392,50.383392 0 0 0 -0.74204,95.66646"
+       id="path8122"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 796.08027,-233.46596 a 23.835162,23.835162 0 0 0 -9.67434,-23.0682"
+       id="path8124"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 796.08027,-233.46596 a 14.173228,14.173228 0 0 0 5.28095,10.8873"
+       id="path8126"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 726.7141,-136.95616 a 163.65833,163.65833 0 0 0 -50.54476,12.0715"
+       id="path8128"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 658.79654,-120.14256 a 70.866142,70.866142 0 0 0 17.3728,-4.7421"
+       id="path8130"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 619.33755,-117.30926 a 293.74894,293.74894 0 0 0 39.45899,-2.8333"
+       id="path8132"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 580.05409,-120.16406 a 293.67424,293.67424 0 0 0 39.28346,2.8548"
+       id="path8134"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 562.38861,-124.93256 a 70.866142,70.866142 0 0 0 17.66548,4.7685"
+       id="path8136"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 562.38861,-124.93256 a 163.65833,163.65833 0 0 0 -50.42947,-12.0236"
+       id="path8138"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 436.67108,-223.99296 a 14.173228,14.173228 0 0 0 5.36523,-10.8461"
+       id="path8140"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 451.88929,-257.83156 a 23.835162,23.835162 0 0 0 -9.85298,22.9925"
+       id="path8142"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 451.88929,-257.83156 a 50.383392,50.383392 0 0 0 0,-95.66926"
+       id="path8144"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 442.03631,-376.49334 a 23.835162,23.835162 0 0 0 9.85298,22.99252"
+       id="path8146"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 442.03631,-376.49334 a 12.274894,12.274894 0 0 0 -5.22937,-11.65645"
+       id="path8148"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 473.49881,-443.03212 a 200.19685,200.19685 0 0 0 -36.69187,54.88233"
+       parametric:d="`M ${478.5098-((size*mm) * 0.353553391)},${-448.04311+((size*mm) * 0.353553391)} A 200.19685,200.19685 0 0 0 436.80694,-388.14979`"
+       id="path8150"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 518.90702,-469.80607 a 7.086614,7.086614 0 0 0 -10.33034,-2.88055"
+       id="path8152"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 518.90702,-469.80607 a 146.31135,146.31135 0 0 0 37.47824,48.9903"
+       id="path8154"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 556.38526,-420.81577 a 140.25883,140.25883 0 0 0 129.63535,-1.95436"
+       id="path8156"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 686.02061,-422.77013 a 146.31135,146.31135 0 0 0 35.01374,-46.25204"
+       id="path8158"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 731.38673,-471.82251 a 7.086614,7.086614 0 0 0 -10.35238,2.80034"
+       id="path8160"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 723.23754,-243.91236 a 3.543307,3.543307 0 0 0 -3.5433,3.5433"
+       id="path8162"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 719.69424,-236.82576 a 3.543307,3.543307 0 0 0 3.5433,3.5433"
+       id="path8164"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 775.14332,-233.28246 a 1.771654,1.771654 0 0 0 1.64311,-2.4342"
+       id="path8166"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 773.68542,-243.40746 a 3.543307,3.543307 0 0 0 -1.82302,-0.5049"
+       id="path8168"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 518.97901,-240.36906 a 3.543307,3.543307 0 0 0 -3.54331,-3.5433"
+       id="path8170"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 466.81084,-243.91236 a 3.543307,3.543307 0 0 0 -1.82301,0.5049"
+       id="path8172"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 461.88681,-235.71666 a 1.771654,1.771654 0 0 0 1.64312,2.4342"
+       id="path8174"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 515.4357,-233.28246 a 3.543307,3.543307 0 0 0 3.54331,-3.5433"
+       id="path8176"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 515.4357,-367.92815 a 3.543307,3.543307 0 0 0 3.54331,-3.5433"
+       id="path8178"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 518.97901,-375.01476 a 3.543307,3.543307 0 0 0 -3.54331,-3.54331"
+       id="path8180"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 463.52993,-378.55807 a 1.771654,1.771654 0 0 0 -1.64312,2.43418"
+       id="path8182"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 464.98783,-368.43309 a 3.543307,3.543307 0 0 0 1.82301,0.50494"
+       id="path8184"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 538.35232,-161.87086 a 1.63529,1.63529 0 0 0 -0.49536,3.1937"
+       id="path8186"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 537.85696,-158.67716 a 264.82073,264.82073 0 0 0 160.43954,0"
+       id="path8188"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 698.2965,-158.67716 a 1.63529,1.63529 0 0 0 -0.49536,-3.1937"
+       id="path8190"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 726.7141,-136.95616 a 200.19685,200.19685 0 0 0 28.48161,-21.87353"
+       parametric:d="`M 726.7141,-136.95616 A 200.19685,200.19685 0 0 0 ${760.2067-((size*mm) * 0.353553391)},${-163.84068+((size*mm) * 0.353553391)}`"
+       id="path8192"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 765.21769,-168.85167 a 200.19685,200.19685 0 0 0 36.14353,-53.72699"
+       parametric:d="`M ${760.2067+((size*mm) * 0.353553391)},${-163.84068-((size*mm) * 0.353553391)} A 200.19685,200.19685 0 0 0 801.36122,-222.57866`"
+       id="path8194"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 508.57668,-472.68662 a 200.19685,200.19685 0 0 0 -25.05589,19.63252"
+       parametric:d="`M 508.57668,-472.68662 A 200.19685,200.19685 0 0 0 ${478.5098+((size*mm) * 0.353553391)},${-448.04311-((size*mm) * 0.353553391)}`"
+       id="path8196"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 802.49861,-386.73156 a 200.19685,200.19685 0 0 0 -36.07143,-55.00455"
+       parametric:d="`M 802.49861,-386.73156 A 200.19685,200.19685 0 0 0 ${761.41619+((size*mm) * 0.353553391)},${-446.7471+((size*mm) * 0.353553391)}`"
+       id="path8198"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 482.22478,-160.03919 a 200.19685,200.19685 0 0 0 29.73436,23.08303"
+       parametric:d="`M ${477.21379+((size*mm) * 0.353553391)},${-165.05018+((size*mm) * 0.353553391)} A 200.19685,200.19685 0 0 0 511.95914,-136.95616`"
+       id="path8200"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 756.4052,-451.75809 a 200.19685,200.19685 0 0 0 -25.01847,-20.06442"
+       parametric:d="`M ${761.41619-((size*mm) * 0.353553391)},${-446.7471-((size*mm) * 0.353553391)} A 200.19685,200.19685 0 0 0 731.38673,-471.82251`"
+       id="path8202"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 436.67108,-223.99296 a 200.19685,200.19685 0 0 0 35.53172,53.93179"
+       parametric:d="`M 436.67108,-223.99296 A 200.19685,200.19685 0 0 0 ${477.21379-((size*mm) * 0.353553391)},${-165.05018-((size*mm) * 0.353553391)}`"
+       id="path8204"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="translate(341.29047,-384.57869)"
+     id="pota transversal1">
+    <path
+       d="m -211.48452,800.66368 -53.14961,0"
+       parametric:d="`M -211.48452,${814.83691-(size*mm)} -264.63413,${814.83691-(size*mm)}`"
+       id="path8231"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -211.48452,814.83691 0,-14.17323"
+       parametric:d="`M -211.48452,814.83691 -211.48452,${814.83691-(size*mm)}`"
+       id="path8233"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -196.42546,814.83691 -15.05906,0"
+       id="path8235"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -196.42546,828.65581 0,-13.8189"
+       id="path8237"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -207.20324,880.63511 10.77778,-51.9793"
+       id="path8239"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -207.94121,1036.2936 0,-148.46459"
+       id="path8241"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -230.9727,1045.1518 14.17322,0"
+       parametric:d="`M ${-238.059315+((size*mm)/2)},1045.1518 -216.79948,1045.1518`"
+       id="path8243"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -230.9727,854.16761 0,190.98419"
+       parametric:d="`M ${-238.059315+((size*mm)/2)},854.16761 ${-238.059315+((size*mm)/2)},1045.1518`"
+       id="path8245"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -245.14593,854.16761 14.17323,0"
+       parametric:d="`M ${-238.059315-((size*mm)/2)},854.16761 ${-238.059315+((size*mm)/2)},854.16761`"
+       id="path8247"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -245.14593,1045.1518 0,-190.98419"
+       parametric:d="`M ${-238.059315-((size*mm)/2)},1045.1518 ${-238.059315-((size*mm)/2)},854.16761`"
+       id="path8249"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -259.31916,1045.1518 14.17323,0"
+       parametric:d="`M -259.31916,1045.1518 ${-238.059315-((size*mm)/2)},1045.1518`"
+       id="path8251"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -268.17743,887.82901 0,148.46459"
+       id="path8253"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -279.69318,828.65581 10.77777,51.9793"
+       id="path8255"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -279.69318,814.83691 0,13.8189"
+       id="path8257"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -264.63413,814.83691 -15.05905,0"
+       id="path8259"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -264.63413,800.66368 0,14.17323"
+       parametric:d="`M -264.63413,${814.83691-(size*mm)} -264.63413,814.83691`"
+       id="path8261"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -216.79948,1045.1518 a 8.858268,8.858268 0 0 0 8.85827,-8.8582"
+       id="path8263"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -268.17743,1036.2936 a 8.858268,8.858268 0 0 0 8.85827,8.8582"
+       id="path8265"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -207.20324,880.63511 a 35.433071,35.433071 0 0 0 -0.73797,7.1939"
+       id="path8267"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -268.17743,887.82901 a 35.433071,35.433071 0 0 0 -0.73798,-7.1939"
+       id="path8269"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="translate(289.68262,-376.11315)"
+     id="pota transversal2">
+    <path
+       d="m -64.865203,791.20437 -53.149607,0"
+       parametric:d="`M -64.865203,${805.3776-(size*mm)} -118.01481,${805.3776-(size*mm)}`"
+       id="path8231-5"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -64.865203,805.3776 0,-14.17323"
+       parametric:d="`M -64.865203,805.3776 -64.865203,${805.3776-(size*mm)}`"
+       id="path8233-5"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -49.806143,805.3776 -15.05906,0"
+       id="path8235-3"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -49.806143,819.1965 0,-13.8189"
+       id="path8237-0"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -60.583923,871.1758 10.77778,-51.9793"
+       id="path8239-5"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -61.321893,1026.8343 0,-148.4646"
+       id="path8241-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -84.353383,1035.6925 14.17322,0"
+       parametric:d="`M ${-91.439998+((size*mm)/2)},1035.6925 -70.180163,1035.6925`"
+       id="path8243-9"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -84.353383,844.7083 0,190.9842"
+       parametric:d="`M ${-91.439998+((size*mm)/2)},844.7083 ${-91.439998+((size*mm)/2)},1035.6925`"
+       id="path8245-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -98.526613,844.7083 14.17323,0"
+       parametric:d="`M ${-91.439998-((size*mm)/2)},844.7083 ${-91.439998+((size*mm)/2)},844.7083`"
+       id="path8247-8"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -98.526613,1035.6925 0,-190.9842"
+       parametric:d="`M ${-91.439998-((size*mm)/2)},1035.6925 ${-91.439998-((size*mm)/2)},844.7083`"
+       id="path8249-7"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -112.69984,1035.6925 14.173227,0"
+       parametric:d="`M -112.69984,1035.6925 ${-91.439998-((size*mm)/2)},1035.6925`"
+       id="path8251-0"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -121.55811,878.3697 0,148.4646"
+       id="path8253-9"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -133.07386,819.1965 10.77777,51.9793"
+       id="path8255-3"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -133.07386,805.3776 0,13.8189"
+       id="path8257-2"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -118.01481,805.3776 -15.05905,0"
+       id="path8259-0"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -118.01481,791.20437 0,14.17323"
+       parametric:d="`M -118.01481,${805.3776-(size*mm)} -118.01481,805.3776`"
+       id="path8261-5"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -70.180163,1035.6925 a 8.858268,8.858268 0 0 0 8.85827,-8.8582"
+       id="path8263-4"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -121.55811,1026.8343 a 8.858268,8.858268 0 0 0 8.85827,8.8582"
+       id="path8265-0"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -60.583923,871.1758 a 35.433071,35.433071 0 0 0 -0.73797,7.1939"
+       id="path8267-6"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m -121.55811,878.3697 a 35.433071,35.433071 0 0 0 -0.73798,-7.1939"
+       id="path8269-0"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="matrix(0,1,-1,0,1595.984,-372.16242)"
+     id="pota transversal3">
+    <path
+       d="m 1407.6342,754.94368 -53.1497,0"
+       parametric:d="`M 1407.6342,${769.11691-(size*mm)} 1354.4845,${769.11691-(size*mm)}`"
+       id="path8231-58"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1407.6342,769.11691 0,-14.17323"
+       parametric:d="`M 1407.6342,769.11691 1407.6342,${769.11691-(size*mm)}`"
+       id="path8233-0"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1422.6932,769.11691 -15.059,0"
+       id="path8235-6"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1422.6932,782.93581 0,-13.8189"
+       id="path8237-6"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1411.9154,834.91511 10.7778,-51.9793"
+       id="path8239-2"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1411.1775,990.57361 0,-148.4646"
+       id="path8241-7"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1388.146,999.43181 14.1732,0"
+       parametric:d="`M ${1381.059355+((size*mm)/2)},999.43181 1402.3192,999.43181`"
+       id="path8243-8"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1388.146,808.44761 0,190.9842"
+       parametric:d="`M ${1381.059355+((size*mm)/2)},808.44761 ${1381.059355+((size*mm)/2)},999.43181`"
+       id="path8245-8"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1373.9727,808.44761 14.1733,0"
+       parametric:d="`M ${1381.059355-((size*mm)/2)},808.44761 ${1381.059355+((size*mm)/2)},808.44761`"
+       id="path8247-4"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1373.9727,999.43181 0,-190.9842"
+       parametric:d="`M ${1381.059355-((size*mm)/2)},999.43181 ${1381.059355-((size*mm)/2)},808.44761`"
+       id="path8249-2"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1359.7995,999.43181 14.1732,0"
+       parametric:d="`M 1359.7995,999.43181 ${1381.059355-((size*mm)/2)},999.43181`"
+       id="path8251-4"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1350.9412,842.10901 0,148.4646"
+       id="path8253-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1339.4255,782.93581 10.7778,51.9793"
+       id="path8255-5"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1339.4255,769.11691 0,13.8189"
+       id="path8257-6"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1354.4845,769.11691 -15.059,0"
+       id="path8259-6"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1354.4845,754.94368 0,14.17323"
+       parametric:d="`M 1354.4845,${769.11691-(size*mm)} 1354.4845,769.11691`"
+       id="path8261-9"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1402.3192,999.43181 a 8.858268,8.858268 0 0 0 8.8583,-8.8582"
+       id="path8263-6"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1350.9412,990.57361 a 8.858268,8.858268 0 0 0 8.8583,8.8582"
+       id="path8265-7"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1411.9154,834.91511 a 35.433071,35.433071 0 0 0 -0.7379,7.1939"
+       id="path8267-7"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1350.9412,842.10901 a 35.433071,35.433071 0 0 0 -0.7379,-7.1939"
+       id="path8269-3"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="translate(-1222.0176,-330.39315)"
+     id="pota transversal4">
+    <path
+       d="m 1543.2176,745.48437 -53.1496,0"
+       parametric:d="`M 1543.2176,${759.6576-(size*mm)} 1490.068,${759.6576-(size*mm)}`"
+       id="path8231-9"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1543.2176,759.6576 0,-14.17323"
+       parametric:d="`M 1543.2176,759.6576 1543.2176,${759.6576-(size*mm)}`"
+       id="path8233-6"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1558.2767,759.6576 -15.0591,0"
+       id="path8235-63"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1558.2767,773.4765 0,-13.8189"
+       id="path8237-9"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1547.4989,825.4558 10.7778,-51.9793"
+       id="path8239-3"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1546.7609,981.1143 0,-148.4646"
+       id="path8241-79"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1523.7295,989.9725 14.1731,0"
+       parametric:d="`M ${1516.642855+((size*mm)/2)},989.9725 1537.9026,989.9725`"
+       id="path8243-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1523.7295,798.9883 0,190.9842"
+       parametric:d="`M ${1516.642855+((size*mm)/2)},798.9883 ${1516.642855+((size*mm)/2)},989.9725`"
+       id="path8245-84"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1509.5562,798.9883 14.1733,0"
+       parametric:d="`M ${1516.642855-((size*mm)/2)},798.9883 ${1516.642855+((size*mm)/2)},798.9883`"
+       id="path8247-0"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1509.5562,989.9725 0,-190.9842"
+       parametric:d="`M ${1516.642855-((size*mm)/2)},989.9725 ${1516.642855-((size*mm)/2)},798.9883`"
+       id="path8249-8"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1495.383,989.9725 14.1732,0"
+       parametric:d="`M 1495.383,989.9725 ${1516.642855-((size*mm)/2)},989.9725`"
+       id="path8251-2"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1486.5247,832.6497 0,148.4646"
+       id="path8253-6"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1475.0089,773.4765 10.7778,51.9793"
+       id="path8255-0"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1475.0089,759.6576 0,13.8189"
+       id="path8257-9"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1490.068,759.6576 -15.0591,0"
+       id="path8259-69"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1490.068,745.48437 0,14.17323"
+       parametric:d="`M 1490.068,${759.6576-(size*mm)} 1490.068,759.6576`"
+       id="path8261-3"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1537.9026,989.9725 a 8.858268,8.858268 0 0 0 8.8583,-8.8582"
+       id="path8263-0"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1486.5247,981.1143 a 8.858268,8.858268 0 0 0 8.8583,8.8582"
+       id="path8265-5"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1547.4989,825.4558 a 35.433071,35.433071 0 0 0 -0.738,7.1939"
+       id="path8267-66"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1486.5247,832.6497 a 35.433071,35.433071 0 0 0 -0.738,-7.1939"
+       id="path8269-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="matrix(0,1,-1,0,618.81111,-1077.0075)"
+     id="pota3">
+    <path
+       d="m 1389.2043,386.37466 c -3.7144,-12.9123 -20.9326,-46.9338 -20.999,-66.88003 -0.071,-21.25654 19.338,-26.52788 26.542,-26.52788"
+       id="path8296"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1262.1937,381.08416 c 0.6199,4.7908 9.2144,39.8169 24.8802,56.6819 17.0401,18.3444 42.4465,15.2018 53.5649,14.0337"
+       id="path8298"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1314.6016,416.98246 a 5.314961,5.314961 0 1 0 -10.6299,0 5.314961,5.314961 0 1 0 10.6299,0 z"
+       id="path8300"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1325.9732,289.42344 a 1.771655,1.771655 0 1 0 -3.5433,0 1.771655,1.771655 0 0 0 3.5433,0 z"
+       id="path8302"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1208.1937,278.79352 0,6.02362"
+       parametric:d="`M 1208.1937,${ 264.62029 + (size*mm)} 1208.1937,${ 270.64391 + (size*mm)}`"
+       id="path8304"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1208.1937,284.81714 14.1732,0"
+       parametric:d="`M 1208.1937,${ 270.64391 + (size*mm)} 1222.3669,${ 270.64391 + (size*mm)}`"
+       id="path8306"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1222.3669,284.81714 0,-6.02362"
+       parametric:d="`M 1222.3669,${ 270.64391 + (size*mm)} 1222.3669,${ 264.62029 + (size*mm)}`"
+       id="path8308"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1222.3669,278.79352 -14.1732,0"
+       parametric:d="`M 1222.3669,${ 264.62029 + (size*mm)} 1208.1937,${ 264.62029 + (size*mm)}`"
+       id="path8310"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1084.178,264.62029 0,15.6783"
+       id="path8312"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1098.3512,264.62029 -14.1732,0"
+       id="path8314"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1098.3512,250.44706 0,14.17323"
+       parametric:d="`M 1098.3512,${264.62029-(size*mm)} 1098.3512,264.62029`"
+       id="path8316"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1117.8393,250.44706 -19.4881,0"
+       parametric:d="`M ${1124.92595-((size*mm)/2)},${264.62029-(size*mm)} 1098.3512,${264.62029-(size*mm)}`"
+       id="path8318"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1117.8393,250.44706 0,53.50394"
+       parametric:d="`M ${1124.92595-((size*mm)/2)},${264.62029-(size*mm)} ${1124.92595-((size*mm)/2)},303.951`"
+       id="path8320"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1117.8393,303.951 14.1733,0"
+       parametric:d="`M ${1124.92595-((size*mm)/2)},303.951 ${1124.92595+((size*mm)/2)},303.951`"
+       id="path8322"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1132.0126,303.951 0,-53.50394"
+       parametric:d="`M ${1124.92595+((size*mm)/2)},303.951 ${1124.92595+((size*mm)/2)},${264.62029-(size*mm)}`"
+       id="path8324"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1151.5008,264.62029 0,-14.17323"
+       parametric:d="`M 1151.5008,264.62029 1151.5008,${264.62029-(size*mm)}`"
+       id="path8326"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1444.674,264.62029 -293.1732,0"
+       id="path8328"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1444.674,250.44706 0,14.17323"
+       parametric:d="`M 1444.674,${264.62029-(size*mm)} 1444.674,264.62029`"
+       id="path8330"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1497.8236,250.44706 -53.1496,0"
+       parametric:d="`M 1497.8236,${264.62029-(size*mm)} 1444.674,${264.62029-(size*mm)}`"
+       id="path8332"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1497.8236,264.62029 0,-14.17323"
+       parametric:d="`M 1497.8236,264.62029 1497.8236,${264.62029-(size*mm)}`"
+       id="path8334"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1501.3669,264.62029 -3.5433,0"
+       id="path8336"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1501.3669,280.21084 0,-15.59055"
+       id="path8338"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1482.5618,280.21084 18.8051,0"
+       id="path8340"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1394.7473,292.96675 61.3018,0"
+       id="path8342"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1361.4063,388.63606 26.0954,0"
+       id="path8344"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1361.4063,396.63606 0,-8"
+       id="path8346"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1333.0599,393.90936 21.2136,7.7211"
+       id="path8348"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1333.0599,403.00596 0,-9.0966"
+       id="path8350"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1356.7435,411.62606 -23.6836,-8.6201"
+       id="path8352"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1361.4063,420.65266 0,-2.3673"
+       id="path8354"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1275.2026,372.78606 -5.7154,0"
+       id="path8356"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1256.8457,362.11436 3.7166,0"
+       id="path8358"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1249.7591,353.20296 0,1.8248"
+       id="path8360"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1222.3669,353.20296 27.3922,0"
+       id="path8362"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1154.1583,484.30536 0,-113.3859"
+       id="path8364"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1104.552,494.93526 38.9764,0"
+       id="path8366"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1093.9221,331.94316 0,152.3622"
+       id="path8368"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1151.5008,250.44706 -19.4882,0"
+       parametric:d="`M 1151.5008,${264.62029-(size*mm)} ${1124.92595+((size*mm)/2)},${264.62029-(size*mm)}`"
+       id="path8370"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1171.8748,353.20296 36.3189,0"
+       id="path8372"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1093.9221,331.94316 a 141.73228,141.73228 0 0 0 -9.7441,-51.64457"
+       id="path8374"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1482.5618,280.21084 a 17.716535,17.716535 0 0 0 -13.8432,6.66031"
+       id="path8376"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1456.0491,292.96675 a 16.214404,16.214404 0 0 0 12.6695,-6.0956"
+       id="path8378"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1387.5017,388.63606 a 1.771654,1.771654 0 0 0 1.7026,-2.2614"
+       id="path8380"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1354.2735,401.63046 a 5.314961,5.314961 0 0 0 7.1328,-4.9944"
+       id="path8382"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1361.4063,418.28536 a 7.086614,7.086614 0 0 0 -4.6628,-6.6593"
+       id="path8384"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1352.3506,445.57846 a 38.626423,38.626423 0 0 0 9.0557,-24.9258"
+       id="path8386"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1340.6388,451.79976 a 17.716535,17.716535 0 0 0 11.7118,-6.2213"
+       id="path8388"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1269.4872,372.78606 a 7.354298,7.354298 0 0 0 -7.2935,8.2981"
+       id="path8390"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1275.2026,372.78606 a 11.513773,11.513773 0 0 0 -1.7392,-4.0059"
+       id="path8392"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1273.4634,368.78016 a 10.519727,10.519727 0 0 0 -12.9011,-6.6658"
+       id="path8394"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1249.7591,355.02776 a 7.086614,7.086614 0 0 0 7.0866,7.0866"
+       id="path8396"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1222.3669,353.20296 a 7.854253,7.854253 0 0 0 -14.1732,0"
+       id="path8398"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1171.8748,353.20296 a 17.716535,17.716535 0 0 0 -17.7165,17.7165"
+       id="path8400"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1143.5284,494.93526 a 10.629921,10.629921 0 0 0 10.6299,-10.6299"
+       id="path8402"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1093.9221,484.30536 a 10.629921,10.629921 0 0 0 10.6299,10.6299"
+       id="path8404"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="matrix(0,-1,1,0,-378.50738,2431.1819)"
+     id="pota4">
+    <path
+       d="m 1767.5767,523.53466 c -3.7143,-12.9123 -20.9326,-46.9338 -20.9989,-66.88003 -0.071,-21.25654 19.3379,-26.52788 26.542,-26.52788"
+       id="path8296-4"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1640.5661,518.24416 c 0.62,4.7908 9.2144,39.8169 24.8802,56.6819 17.0401,18.3444 42.4466,15.2018 53.5649,14.0337"
+       id="path8298-7"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1692.9741,554.14246 a 5.314961,5.314961 0 1 0 -10.6299,0 5.314961,5.314961 0 1 0 10.6299,0 z"
+       id="path8300-7"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1704.3457,426.58344 a 1.771655,1.771655 0 1 0 -3.5433,0 1.771655,1.771655 0 0 0 3.5433,0 z"
+       id="path8302-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1586.5661,415.95352 0,6.02362"
+       parametric:d="`M 1586.5661,${401.78029 + (size*mm)} 1586.5661,${407.80391 + (size*mm)}`"
+       id="path8304-4"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1586.5661,421.97714 14.1733,0"
+       parametric:d="`M 1586.5661,${407.80391 + (size*mm)} 1600.7394,${407.80391 + (size*mm)}`"
+       id="path8306-2"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1600.7394,421.97714 0,-6.02362"
+       parametric:d="`M 1600.7394,${407.80391 + (size*mm)} 1600.7394,${401.78029 + (size*mm)}`"
+       id="path8308-2"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1600.7394,415.95352 -14.1733,0"
+       parametric:d="`M 1600.7394,${401.78029 + (size*mm)} 1586.5661,${401.78029 + (size*mm)}`"
+       id="path8310-3"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1462.5504,401.78029 0,15.6783"
+       id="path8312-0"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1476.7236,401.78029 -14.1732,0"
+       id="path8314-5"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1476.7236,387.60706 0,14.17323"
+       parametric:d="`M 1476.7236,${401.78029-(size*mm)} 1476.7236,401.78029`"
+       id="path8316-2"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1496.2123,387.60706 -19.4887,0"
+       parametric:d="`M ${1503.2989-((size*mm)/2)},${401.78029-(size*mm)} 1476.7236,${401.78029-(size*mm)}`"
+       id="path8318-4"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1496.2123,387.60706 0,53.50394"
+       parametric:d="`M ${1503.2989-((size*mm)/2)},${401.78029-(size*mm)} ${1503.2989-((size*mm)/2)},441.111`"
+       id="path8320-3"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1496.2123,441.111 14.1732,0"
+       parametric:d="`M ${1503.2989-((size*mm)/2)},441.111 ${1503.2989+((size*mm)/2)},441.111`"
+       id="path8322-3"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1510.3855,441.111 0,-53.50394"
+       parametric:d="`M ${1503.2989+((size*mm)/2)},441.111 ${1503.2989+((size*mm)/2)},${401.78029-(size*mm)}`"
+       id="path8324-5"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1529.8732,401.78029 0,-14.17323"
+       parametric:d="`M 1529.8732,401.78029 1529.8732,${401.78029-(size*mm)}`"
+       id="path8326-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1823.0465,401.78029 -293.1733,0"
+       id="path8328-7"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1823.0465,387.60706 0,14.17323"
+       parametric:d="`M 1823.0465,${401.78029-(size*mm)} 1823.0465,401.78029`"
+       id="path8330-5"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1876.1961,387.60706 -53.1496,0"
+       parametric:d="`M 1876.1961,${401.78029-(size*mm)} 1823.0465,${401.78029-(size*mm)}`"
+       id="path8332-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1876.1961,401.78029 0,-14.17323"
+       parametric:d="`M 1876.1961,401.78029 1876.1961,${401.78029-(size*mm)}`"
+       id="path8334-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1879.7394,401.78029 -3.5433,0"
+       id="path8336-3"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1879.7394,417.37084 0,-15.59055"
+       id="path8338-2"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1860.9342,417.37084 18.8052,0"
+       id="path8340-0"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1773.1198,430.12675 61.3017,0"
+       id="path8342-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1739.7787,525.79606 26.0954,0"
+       id="path8344-3"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1739.7787,533.79606 0,-8"
+       id="path8346-5"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1711.4323,531.06936 21.2137,7.7211"
+       id="path8348-2"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1711.4323,540.16596 0,-9.0966"
+       id="path8350-0"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1735.1159,548.78606 -23.6836,-8.6201"
+       id="path8352-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1739.7787,557.81266 0,-2.3673"
+       id="path8354-8"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1653.575,509.94606 -5.7154,0"
+       id="path8356-3"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1635.2182,499.27436 3.7165,0"
+       id="path8358-5"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1628.1316,490.36296 0,1.8248"
+       id="path8360-5"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1600.7394,490.36296 27.3922,0"
+       id="path8362-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1532.5307,621.46536 0,-113.3859"
+       id="path8364-8"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1482.9244,632.09526 38.9764,0"
+       id="path8366-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1472.2945,469.10316 0,152.3622"
+       id="path8368-5"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1529.8732,387.60706 -19.4877,0"
+       parametric:d="`M 1529.8732,${401.78029-(size*mm)} ${1503.2989+((size*mm)/2)},${401.78029-(size*mm)}`"
+       id="path8370-0"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1550.2472,490.36296 36.3189,0"
+       id="path8372-6"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1472.2945,469.10316 a 141.73228,141.73228 0 0 0 -9.7441,-51.64457"
+       id="path8374-6"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1860.9342,417.37084 a 17.716535,17.716535 0 0 0 -13.8432,6.66031"
+       id="path8376-5"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1834.4215,430.12675 a 16.214404,16.214404 0 0 0 12.6695,-6.0956"
+       id="path8378-8"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1765.8741,525.79606 a 1.771654,1.771654 0 0 0 1.7026,-2.2614"
+       id="path8380-0"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1732.646,538.79046 a 5.314961,5.314961 0 0 0 7.1327,-4.9944"
+       id="path8382-0"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1739.7787,555.44536 a 7.086614,7.086614 0 0 0 -4.6628,-6.6593"
+       id="path8384-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1730.723,582.73846 a 38.626423,38.626423 0 0 0 9.0557,-24.9258"
+       id="path8386-7"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1719.0112,588.95976 a 17.716535,17.716535 0 0 0 11.7118,-6.2213"
+       id="path8388-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1647.8596,509.94606 a 7.354298,7.354298 0 0 0 -7.2935,8.2981"
+       id="path8390-0"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1653.575,509.94606 a 11.513773,11.513773 0 0 0 -1.7391,-4.0059"
+       id="path8392-3"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1651.8359,505.94016 a 10.519727,10.519727 0 0 0 -12.9012,-6.6658"
+       id="path8394-3"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1628.1316,492.18776 a 7.086614,7.086614 0 0 0 7.0866,7.0866"
+       id="path8396-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1600.7394,490.36296 a 7.854253,7.854253 0 0 0 -14.1733,0"
+       id="path8398-6"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1550.2472,490.36296 a 17.716535,17.716535 0 0 0 -17.7165,17.7165"
+       id="path8400-7"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1521.9008,632.09526 a 10.629921,10.629921 0 0 0 10.6299,-10.6299"
+       id="path8402-1"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 1472.2945,621.46536 a 10.629921,10.629921 0 0 0 10.6299,10.6299"
+       id="path8404-8"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="matrix(0,1,-1,0,396.32264,602.33788)"
+     id="pota darrere2">
+    <path
+       d="m 101.43679,-34.449098 a 5.3149615,5.3149615 0 1 0 -10.629923,0 5.3149615,5.3149615 0 1 0 10.629923,0 z"
+       id="path8431"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 48.074587,-87.758398 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+       id="path8433"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 101.43679,-87.811298 a 5.3149615,5.3149615 0 1 0 -10.629923,0 5.3149615,5.3149615 0 1 0 10.629923,0 z"
+       id="path8435"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 48.225897,-34.396198 a 5.314961,5.314961 0 1 0 -10.62992,0 5.314961,5.314961 0 1 0 10.62992,0 z"
+       id="path8437"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 127.49557,-69.776758 -50.613893,0"
+       parametric:d="`M 127.49557,${-62.690143-((size*mm)/2)} ${69.795062+((size*mm)/2)},${-62.690143-((size*mm)/2)}`"
+       id="path8439"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 76.881677,-69.776758 0,-34.547242"
+       parametric:d="`M ${69.795062+((size*mm)/2)},${-62.690143-((size*mm)/2)} ${69.795062+((size*mm)/2)},-104.324`"
+       id="path8441"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 76.881677,-104.324 -14.17323,0"
+       parametric:d="`M ${69.795062+((size*mm)/2)},-104.324 ${69.795062-((size*mm)/2)},-104.324`"
+       id="path8443"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 62.708447,-104.324 0,34.547242"
+       parametric:d="`M ${69.795062-((size*mm)/2)},-104.324 ${69.795062-((size*mm)/2)},${-62.690143-((size*mm)/2)}`"
+       id="path8445"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 62.708447,-69.776758 -33.66142,0"
+       parametric:d="`M ${69.795062-((size*mm)/2)},${-62.690143-((size*mm)/2)} 29.047027,${-62.690143-((size*mm)/2)}`"
+       id="path8447"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 29.047027,-69.776758 0,14.17323"
+       parametric:d="`M 29.047027,${-62.690143-((size*mm)/2)} 29.047027,${-62.690143+((size*mm)/2)}`"
+       id="path8449"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 29.047027,-55.603528 33.66142,0"
+       parametric:d="`M 29.047027,${-62.690143+((size*mm)/2)} ${69.795062-((size*mm)/2)},${-62.690143+((size*mm)/2)}`"
+       id="path8451"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 62.708447,-55.603528 0,34.547234"
+       parametric:d="`M ${69.795062-((size*mm)/2)},${-62.690143+((size*mm)/2)} ${69.795062-((size*mm)/2)},-21.056294`"
+       id="path8453"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 62.708447,-21.056294 14.17323,0"
+       parametric:d="`M ${69.795062-((size*mm)/2)},-21.056294 ${69.795062+((size*mm)/2)},-21.056294`"
+       id="path8455"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 76.881677,-55.603528 200.456023,0"
+       parametric:d="`M ${69.795062+((size*mm)/2)},${-62.690143+((size*mm)/2)} 277.3377,${-62.690143+((size*mm)/2)}`"
+       id="path8457"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 258.56557,-39.667198 219.07089,-0.17249429"
+       id="path8459"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 76.881677,-21.056294 0,-34.547234"
+       parametric:d="`M ${69.795062+((size*mm)/2)},-21.056294 ${69.795062+((size*mm)/2)},${-62.690143+((size*mm)/2)}`"
+       id="path8461"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 279.04119,-53.522298 a 1.771654,1.771654 0 0 0 -1.70349,-2.08123"
+       parametric:d="`M 279.04119,-53.522298 A 1.771654,1.771654 0 0 0 277.3377,${-62.690143+((size*mm)/2)}`"
+       id="path8463"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 260.88359,-40.479998 a 18.009559,18.009559 0 0 0 18.1576,-13.0423"
+       id="path8465"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 260.88359,-40.479998 a 2.834646,2.834646 0 0 0 -2.31802,0.8128"
+       id="path8467"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 209.65467,2.7698057 a 10.629921,10.629921 0 0 0 9.41622,-2.94229999"
+       id="path8469"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 209.65467,2.7698057 A 157.56213,157.56213 0 0 0 124.69111,-19.830194"
+       id="path8471"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 124.69111,-19.830194 A 54.486732,54.486732 0 0 0 94.517417,-9.8765943"
+       id="path8473"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 127.49557,-69.776758 A 58.464567,58.464567 0 1 0 94.517417,-9.8765943"
+       parametric:d="`M 127.49557,${-62.690143-((size*mm)/2)} A 58.464567,58.464567 0 1 0 94.517417,-9.8765943`"
+       id="path8475"
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="layer2"
+     inkscape:label="Grabado"
+     style="display:inline"
+     transform="translate(1.0083832,-0.5041849)">
+    <g
+       id="g6256"
+       transform="translate(-0.7159461,0.016445)">
+      <g
+         id="g8179"
+         transform="matrix(1.25,-1.25,1.25,1.25,-1035.378,14.28807)" />
+      <g
+         id="g6450">
+        <g
+           transform="matrix(1.25,0,0,1.25,-0.3277,0.28806971)"
+           id="g6793"
+           style="stroke:#0000ff;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path6795"
+             style="fill:none;stroke:#0000ff;stroke-width:0.40000001;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 495.395,378.953 0,-2.836"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(0.89619005,0,0,0.89599416,203.92594,118.17733)"
+           id="g7925"
+           style="stroke:#0000ff;stroke-width:0.07908355;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path7927-6"
+             style="fill:none;stroke:#0000ff;stroke-width:0.07908355;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 640.094,392.523 -127.156,0 c -3.985,0 -7.188,-3.207 -7.188,-7.183 l 0,-127.16 c 0,-3.989 3.203,-7.192 7.188,-7.192 l 127.156,0 c 3.984,0 7.191,3.203 7.191,7.192 l 0,127.16 c 0,3.976 -3.207,7.183 -7.191,7.183 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(0,-1.25,1.25,0,295.05012,1076.5095)"
+           id="g7933"
+           style="stroke:#0000ff;stroke-width:0.05669291;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path7935-2"
+             style="fill:none;stroke:#0000ff;stroke-width:0.05669291;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 564.449,416.113 1.192,-2.058 -0.848,0 0,-10.516 2.16,2.047 c 0.145,0.172 0.238,0.402 0.242,0.637 l 0,1.718 c -0.398,0.141 -0.687,0.52 -0.687,0.969 0,0.567 0.465,1.028 1.031,1.028 0.563,0 1.031,-0.461 1.031,-1.028 0,-0.449 -0.289,-0.828 -0.691,-0.969 l 0,-1.699 c 0,-0.461 -0.254,-0.941 -0.547,-1.25 0.008,0.008 0.012,0.016 -0.004,0 -0.008,-0.004 -2.293,-2.172 -2.293,-2.172 -0.14,-0.175 -0.238,-0.402 -0.242,-0.636 l 0,-1.188 c 0.785,-0.156 1.375,-0.851 1.375,-1.687 0,-0.95 -0.766,-1.719 -1.719,-1.719 -0.945,0 -1.715,0.769 -1.715,1.719 0,0.836 0.59,1.531 1.375,1.687 l 0,3.758 c -0.004,0.238 -0.101,0.465 -0.242,0.637 0,0 -2.285,2.168 -2.293,2.171 -0.019,0.02 -0.012,0.012 0,0 -0.297,0.309 -0.551,0.79 -0.551,1.254 l 0,1.637 -0.687,0 0,2.059 2.059,0 0,-2.059 -0.692,0 c 0,0 0.004,-0.433 0.004,-1.656 0.004,-0.235 0.098,-0.465 0.242,-0.641 l 2.16,-2.043 0,7.942 -0.847,0 1.187,2.058 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(0,1.25,1.25,0,-0.3277,0.28806971)"
+           id="g7941"
+           style="stroke:#0000ff;stroke-opacity:1">
+          <path
+             ns5422364:nodetypes="cccscsccscccccccc"
+             ns5245954:connector-curvature="0"
+             id="path7943-1"
+             style="fill:none;stroke:#0000ff;stroke-width:0.80000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 657.531,153.875 c -0.258,0.395 -0.242,0.465 2.129,11.668 0.457,2.168 0.465,2.176 3.09,2.176 1.539,0.008 1.883,0.047 1.883,0.25 0,0.133 -0.156,0.328 -0.344,0.429 -0.508,0.27 -0.996,1.168 -0.996,1.836 0,1.813 1.949,2.938 3.48,2.004 1.317,-0.804 1.344,-3.144 0.043,-3.84 -0.191,-0.101 -0.343,-0.289 -0.343,-0.418 0,-0.179 0.449,-0.242 2.086,-0.285 1.578,-0.043 2.144,-0.117 2.328,-0.308 0.133,-0.137 0.433,-1.192 0.668,-2.34 0.238,-1.152 0.843,-4.051 1.347,-6.445 0.828,-3.946 0.891,-4.383 0.668,-4.727 l -0.246,-0.375 -15.547,0 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(0,-1.25,-1.25,0,-0.3277,0.28806971)"
+           id="g7945"
+           style="stroke:#0000ff;stroke-opacity:1">
+          <path
+             ns5422364:nodetypes="cccscsccscccccccc"
+             ns5245954:connector-curvature="0"
+             id="path7947-0"
+             style="fill:none;stroke:#0000ff;stroke-width:0.80000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m -602.547,-147.031 c -0.258,0.398 -0.242,0.465 2.129,11.668 0.457,2.168 0.465,2.175 3.09,2.175 1.539,0.012 1.883,0.051 1.883,0.25 0,0.137 -0.157,0.329 -0.344,0.434 -0.508,0.266 -0.996,1.168 -0.996,1.836 0,1.809 1.949,2.934 3.48,2.004 1.317,-0.805 1.344,-3.148 0.043,-3.84 -0.191,-0.105 -0.343,-0.289 -0.343,-0.418 0,-0.183 0.449,-0.242 2.085,-0.285 1.579,-0.043 2.145,-0.117 2.329,-0.309 0.132,-0.14 0.433,-1.191 0.668,-2.343 0.238,-1.149 0.843,-4.051 1.347,-6.442 0.828,-3.945 0.891,-4.387 0.668,-4.73 l -0.246,-0.375 -15.547,0 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(0,-1.25,-1.25,0,-0.3277,0.28806971)"
+           id="g7949"
+           style="stroke:#0000ff;stroke-opacity:1">
+          <path
+             ns5422364:nodetypes="cccscsccscccccccc"
+             ns5245954:connector-curvature="0"
+             id="path7951-2"
+             style="fill:none;stroke:#0000ff;stroke-width:0.80000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m -267.172,-145.754 c -0.258,0.395 -0.242,0.465 2.129,11.668 0.457,2.168 0.465,2.176 3.09,2.176 1.539,0.008 1.883,0.047 1.883,0.25 0,0.133 -0.153,0.328 -0.344,0.43 -0.508,0.269 -0.996,1.168 -0.996,1.835 0,1.813 1.949,2.938 3.48,2.004 1.317,-0.804 1.344,-3.144 0.043,-3.839 -0.191,-0.102 -0.34,-0.29 -0.34,-0.418 0,-0.18 0.446,-0.243 2.086,-0.286 1.575,-0.043 2.141,-0.117 2.325,-0.308 0.132,-0.137 0.433,-1.192 0.671,-2.34 0.235,-1.152 0.84,-4.051 1.344,-6.445 0.828,-3.946 0.891,-4.383 0.668,-4.727 l -0.246,-0.375 -15.547,0 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(0,1.25,1.25,0,-0.3277,0.28806971)"
+           id="g7953"
+           style="stroke:#0000ff;stroke-opacity:1">
+          <path
+             ns5422364:nodetypes="cccscsccscccccccc"
+             ns5245954:connector-curvature="0"
+             id="path7955-9"
+             style="fill:none;stroke:#0000ff;stroke-width:0.80000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 177.559,155.148 c -0.258,0.395 -0.243,0.465 2.129,11.668 0.457,2.168 0.464,2.176 3.089,2.176 1.539,0.008 1.883,0.047 1.883,0.25 0,0.133 -0.156,0.328 -0.344,0.43 -0.507,0.269 -0.996,1.168 -0.996,1.836 0,1.812 1.95,2.937 3.481,2.004 1.316,-0.805 1.344,-3.145 0.043,-3.84 -0.192,-0.102 -0.344,-0.289 -0.344,-0.418 0,-0.18 0.449,-0.242 2.086,-0.285 1.578,-0.043 2.144,-0.117 2.328,-0.309 0.133,-0.137 0.434,-1.191 0.668,-2.34 0.238,-1.152 0.844,-4.05 1.348,-6.445 0.828,-3.945 0.89,-4.383 0.668,-4.727 l -0.246,-0.375 -15.547,0 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(1.25,0,0,1.25,-0.3277,0.28806971)"
+           id="g7957"
+           style="stroke:#0000ff;stroke-width:0.05669291;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path7959-2"
+             style="fill:none;stroke:#0000ff;stroke-width:0.05669291;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 536.422,714.16 5.691,0 0,3.813 -1.894,0 0,-1.907 -1.903,0 3.797,7.594 0,1.918 -5.691,0 0,-3.808 1.894,0 0,1.89 1.903,0 -3.797,-7.594 0,-1.906 z m 11.09,0 1.89,0 0,11.418 -1.89,0 0,-5.715 -0.95,0.953 -0.953,-0.953 0,5.715 -1.894,0 0,-11.418 1.894,0 0.953,3.813 0.95,-3.813 z m 7.265,1.418 0,6.895 -1.906,0 0,-6.895 1.906,0 z m -3.793,-1.453 0,11.453 1.887,0 0,-1.203 2.031,0 0,1.203 1.797,0 0,-11.453 -5.715,0 z m 9.211,6.691 -0.953,0 c -0.258,0 -0.484,-0.086 -0.672,-0.265 -0.179,-0.188 -0.265,-0.414 -0.265,-0.688 l 0,-4.765 c 0,-0.258 0.086,-0.481 0.265,-0.657 0.188,-0.191 0.414,-0.281 0.672,-0.281 l 4.75,0 0,11.418 -1.887,0 0,-4.762 -1.91,4.762 -1.89,0 1.89,-4.762 z m 0,-1.89 1.91,0 0,-2.86 -1.91,0 0,2.86 z m 9.168,-2.848 1.832,0 0,-1.918 -5.5,0 0,1.918 1.828,0 0,9.5 1.84,0 0,-9.5 z m 9.215,-0.98 c 0,-0.258 -0.094,-0.481 -0.281,-0.657 -0.18,-0.191 -0.395,-0.281 -0.656,-0.281 l -4.75,0 0,11.418 1.89,0 0,-4.762 2.86,0 c 0.261,0 0.476,-0.086 0.656,-0.265 0.187,-0.188 0.281,-0.414 0.281,-0.688 l 0,-4.765 z m -3.797,0.968 1.91,0 0,2.86 -1.91,0 0,-2.86 z m 9.203,-1.906 0,4.766 -1.906,0 0,-4.766 -1.887,0 0,11.418 1.887,0 0,-4.762 1.906,0 0,4.762 1.891,0 0,-11.418 -1.891,0 z m 7.954,2.168 -0.75,0 0,-2.168 -1.723,0 0,2.168 -0.813,0 c -0.179,0.098 -0.328,0.188 -0.453,0.27 -0.117,0.07 -0.211,0.144 -0.281,0.218 -0.137,0.137 -0.293,0.399 -0.469,0.782 l 0,4.375 c 0.125,0.25 0.258,0.453 0.41,0.605 0.141,0.152 0.364,0.328 0.668,0.535 l 0.875,0 0,2.465 1.844,0 0,-2.465 0.875,0 c 0.176,-0.082 0.32,-0.16 0.422,-0.238 0.113,-0.066 0.207,-0.145 0.281,-0.23 0.074,-0.094 0.129,-0.192 0.172,-0.297 0.051,-0.106 0.098,-0.231 0.141,-0.375 l 0,-4.5 c -0.18,-0.332 -0.336,-0.563 -0.469,-0.688 -0.074,-0.062 -0.172,-0.129 -0.297,-0.207 -0.117,-0.066 -0.258,-0.152 -0.433,-0.25 z m -2.598,5.207 0,-3.609 1.906,0 0,3.609 -1.906,0 z m 6.371,-7.375 3.816,0 c 0.254,0 0.473,0.09 0.653,0.281 0.187,0.176 0.281,0.399 0.281,0.657 l 0,10.48 -1.891,0 0,-9.527 -1.875,0 0,9.527 -1.918,0 0,-10.48 c 0,-0.258 0.086,-0.481 0.262,-0.657 0.191,-0.191 0.41,-0.281 0.672,-0.281 z m 12.047,3.813 0,-2.875 c 0,-0.258 -0.094,-0.481 -0.278,-0.657 -0.183,-0.191 -0.402,-0.281 -0.66,-0.281 l -3.812,0 c -0.262,0 -0.481,0.09 -0.672,0.281 -0.18,0.176 -0.266,0.399 -0.266,0.657 l 0,9.527 c 0,0.277 0.086,0.5 0.266,0.691 0.191,0.176 0.41,0.262 0.672,0.262 l 3.812,0 c 0.258,0 0.477,-0.086 0.66,-0.262 0.184,-0.191 0.278,-0.414 0.278,-0.691 l 0,-2.855 -1.891,0 0,1.89 -1.906,0 0,-2.957 3.797,0 0,-2.73 z m -1.891,1.062 -1.906,0 0,-2.969 1.906,0 0,2.969 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(-1.249393,0.01092933,-0.01268272,-1.5241486,0.02092532,-216.39902)"
+           id="g7961"
+           style="stroke:#0000ff;stroke-width:0.36231893;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path7963-6"
+             style="fill:none;stroke:#0000ff;stroke-width:0.36231893;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.72463788, 2.17391363;stroke-dashoffset:0;stroke-opacity:1"
+             d="M -658.01526,-531.81007 -658.061,-735.936 c -0.004,-6.53 5.261,-11.791 11.788,-11.787 l 156.766,-0.005 c 6.531,0.003 11.782,5.256 11.782,11.79 l 0.0228,206.68139"
+             ns5422364:nodetypes="cccccc"
+             inkscape:connector-curvature="0" />
+          <path
+             ns5245954:connector-curvature="0"
+             style="opacity:0.75800003;fill:none;stroke:#0000ff;stroke-width:0.05135229;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             d="m -493.07794,-555.94162 -150.034,-1.07586 c -3.53177,-0.0253 -6.35205,-2.31153 -6.32348,-5.12601 l 0.0659,-6.49451 c 0.0286,-2.81448 2.89485,-5.0599 6.42661,-5.03457 l 150.034,1.07586 c 3.53179,0.0253 6.35207,2.31152 6.3235,5.126 l -0.0659,6.49451 c -0.0286,2.81448 -2.89486,5.0599 -6.42664,5.03458 z"
+             id="rect8343"
+             inkscape:connector-curvature="0" />
+          <g
+             id="g5633"
+             transform="matrix(1.650452,-6.2508815e-4,-8.8488814e-4,1.7376172,374.29944,416.64147)"
+             style="fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+            <g
+               id="text8345"
+               style="font-style:normal;font-weight:normal;font-size:10.86956787px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="matrix(-1.1044557,-0.0079198,0.00919038,-0.90535746,0,0)">
+              <path
+                 id="path15388"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 d="m 497.14599,621.27745 0.75362,0 0,-0.75362 1.24638,0 0,1.69565 -3.26087,0 0,-4.71014 1.26087,0 0,3.76811 z"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path15390"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 d="m 500.98114,620.80644 0.74637,0 0,-2.54348 -0.74637,0 0,2.54348 z m -1.26087,-3.3116 3.27536,0 0,4.72464 -1.2029,0 0,-0.47826 -0.81159,0 0,0.47826 -1.26087,0 0,-4.72464 z"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path15392"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 d="m 505.82353,618.46586 0,3.75362 -1.22464,0 0,-3.75362 -0.95652,0 0,-0.95652 3.15217,0 0,0.95652 -0.97101,0 z"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path15394"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 d="m 508.68075,619.44412 0.75363,0 0,-0.98551 -0.75363,0 0,0.98551 z m 2,0.84783 -2,0 0,0.9855 0.75363,0 0,-0.75362 1.24637,0 0,1.22464 q 0,0.1884 -0.18116,0.33333 -0.18116,0.13768 -0.44203,0.13768 l -2.00724,0 q -0.13044,0 -0.24638,-0.0362 -0.1087,-0.0362 -0.19565,-0.10145 -0.087,-0.0652 -0.13768,-0.15217 -0.0507,-0.087 -0.0507,-0.18116 l 0,-3.76812 q 0,-0.0942 0.0507,-0.18116 0.0507,-0.087 0.13768,-0.15217 0.087,-0.0652 0.19565,-0.10145 0.11594,-0.0362 0.24638,-0.0362 l 2.00724,0 q 0.26087,0 0.44203,0.14492 0.18116,0.13769 0.18116,0.32609 l 0,2.3116 z"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path15396"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 d="m 513.76228,620.21948 0.74637,1.38406 0,0.28986 -0.34782,0.32608 -0.7029,0 -0.53623,-1.08695 -0.53624,1.08695 -0.69565,0 -0.35507,-0.32608 0,-0.28261 0.65942,-1.37682 -0.52174,0 q -0.1087,-0.13043 -0.1087,-0.33333 l 0,-0.058 q 0.007,-0.26812 0.18841,-0.3913 l 0.42029,0 -0.63768,-1.43479 0,-0.2971 0.35507,-0.26087 0.69565,0 0.53624,1.05073 0.37681,-0.73913 0.28985,-0.33334 0.3116,0.0217 0.26087,0 0.34782,0.26087 0,0.2971 -0.74637,1.43479 0.57971,0 q 0.16666,0.12318 0.16666,0.40579 0,0.2971 -0.25362,0.36232 l -0.49275,0 z"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path15398"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 d="m 520.78741,618.45137 0,-0.94203 -2.67391,0 q -0.13044,0 -0.24638,0.0362 -0.10869,0.0362 -0.19565,0.10145 -0.087,0.0652 -0.13768,0.15217 -0.0507,0.087 -0.0507,0.18116 l 0,3.76812 q 0,0.0942 0.0507,0.18116 0.0507,0.087 0.13768,0.15217 0.087,0.0652 0.19565,0.10145 0.11594,0.0362 0.24638,0.0362 l 2.02898,0 q 0.13044,0 0.24638,-0.0362 0.12319,-0.0362 0.21015,-0.10145 0.087,-0.0652 0.13768,-0.15217 0.0507,-0.087 0.0507,-0.18116 l 0,-1.45652 0.62319,0 0,-0.84783 -2.65942,0 0,-0.99275 2.03623,0 z m -2.03623,1.84058 0.76087,0 0,0.9855 -0.76087,0 0,-0.9855 z"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path15400"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 d="m 527.56538,619.20499 -1.24638,0 0,-0.74638 -0.75362,0 0,0.98551 0.89855,0 0,0.84783 -0.89855,0 0,0.9855 0.75362,0 0,-0.75362 1.24638,0 0,1.22464 q 0,0.1884 -0.18116,0.33333 -0.18116,0.13768 -0.44203,0.13768 l -2.00725,0 q -0.13043,0 -0.24637,-0.0362 -0.1087,-0.0362 -0.19565,-0.10145 -0.087,-0.0652 -0.13769,-0.15217 -0.0507,-0.087 -0.0507,-0.18116 l 0,-3.76812 q 0,-0.0942 0.0507,-0.18116 0.0507,-0.087 0.13769,-0.15217 0.087,-0.0652 0.19565,-0.10145 0.11594,-0.0362 0.24637,-0.0362 l 2.00725,0 q 0.26087,0 0.44203,0.14492 0.18116,0.13769 0.18116,0.32609 l 0,1.22464 z"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path15402"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 d="m 529.41502,621.27745 0.75362,0 0,-0.75362 1.24638,0 0,1.69565 -3.26087,0 0,-4.71014 1.26087,0 0,3.76811 z"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path15404"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 d="m 533.25016,620.80644 0.74638,0 0,-2.54348 -0.74638,0 0,2.54348 z m -1.26087,-3.3116 3.27537,0 0,4.72464 -1.2029,0 0,-0.47826 -0.8116,0 0,0.47826 -1.26087,0 0,-4.72464 z"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path15406"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 d="m 535.85342,617.50934 0,0.86956 1.93479,2.89855 -0.67392,0 0,-0.75362 -1.26087,0 0,1.69565 3.26087,0 0,-0.86956 -1.92753,-2.89131 0.68116,0 0,0.74638 1.24637,0 0,-1.69565 -3.26087,0 z"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path15408"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 d="m 541.94219,618.46586 0,3.75362 -1.22463,0 0,-3.75362 -0.95653,0 0,-0.95652 3.15218,0 0,0.95652 -0.97102,0 z"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path15410"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 d="m 544.58928,617.50934 0,4.71014 -1.08696,0 0,-4.71014 1.08696,0 z"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path15412"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 d="m 548.41287,619.20499 -1.24638,0 0,-0.74638 -0.75362,0 0,2.81884 0.75362,0 0,-0.75362 1.24638,0 0,1.22464 q 0,0.1884 -0.18116,0.33333 -0.18116,0.13768 -0.44203,0.13768 l -2.00725,0 q -0.13043,0 -0.24637,-0.0362 -0.1087,-0.0362 -0.19565,-0.10145 -0.087,-0.0652 -0.13769,-0.15217 -0.0507,-0.087 -0.0507,-0.18116 l 0,-3.76812 q 0,-0.0942 0.0507,-0.18116 0.0507,-0.087 0.13769,-0.15217 0.087,-0.0652 0.19565,-0.10145 0.11594,-0.0362 0.24637,-0.0362 l 2.00725,0 q 0.26087,0 0.44203,0.14492 0.18116,0.13769 0.18116,0.32609 l 0,1.22464 z"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+          <path
+             ns5245954:connector-curvature="0"
+             style="opacity:0.75800003;fill:none;stroke:#0000ff;stroke-width:0.05135229;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:0.20540915, 0.4108183;stroke-dashoffset:0;stroke-opacity:1"
+             d="m -492.61128,-662.22686 -149.51283,-1.07213 c -3.51951,-0.0252 -6.3299,-2.31143 -6.30133,-5.12599 l 0.0659,-6.49468 c 0.0286,-2.81456 2.88497,-5.06011 6.40448,-5.03488 l 149.51282,1.07212 c 3.51951,0.0252 6.32991,2.31143 6.30134,5.12599 l -0.0659,6.49468 c -0.0286,2.81456 -2.88497,5.06012 -6.40448,5.03489 z"
+             id="rect8355"
+             inkscape:connector-curvature="0" />
+          <g
+             transform="matrix(1.650452,-6.2508815e-4,-8.8488814e-4,1.7376172,375.37783,310.40794)"
+             id="g5649"
+             style="fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+            <g
+               transform="matrix(-1.1044557,-0.0079198,0.00919038,-0.90535746,0,0)"
+               style="font-style:normal;font-weight:normal;font-size:10.86956787px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="g5651">
+              <path
+                 ns5245954:connector-curvature="0"
+                 d="m 497.14599,621.27745 0.75362,0 0,-0.75362 1.24638,0 0,1.69565 -3.26087,0 0,-4.71014 1.26087,0 0,3.76811 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path5653"
+                 inkscape:connector-curvature="0" />
+              <path
+                 ns5245954:connector-curvature="0"
+                 d="m 500.98114,620.80644 0.74637,0 0,-2.54348 -0.74637,0 0,2.54348 z m -1.26087,-3.3116 3.27536,0 0,4.72464 -1.2029,0 0,-0.47826 -0.81159,0 0,0.47826 -1.26087,0 0,-4.72464 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path5655"
+                 inkscape:connector-curvature="0" />
+              <path
+                 ns5245954:connector-curvature="0"
+                 d="m 505.82353,618.46586 0,3.75362 -1.22464,0 0,-3.75362 -0.95652,0 0,-0.95652 3.15217,0 0,0.95652 -0.97101,0 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path5657"
+                 inkscape:connector-curvature="0" />
+              <path
+                 ns5245954:connector-curvature="0"
+                 d="m 508.68075,619.44412 0.75363,0 0,-0.98551 -0.75363,0 0,0.98551 z m 2,0.84783 -2,0 0,0.9855 0.75363,0 0,-0.75362 1.24637,0 0,1.22464 q 0,0.1884 -0.18116,0.33333 -0.18116,0.13768 -0.44203,0.13768 l -2.00724,0 q -0.13044,0 -0.24638,-0.0362 -0.1087,-0.0362 -0.19565,-0.10145 -0.087,-0.0652 -0.13768,-0.15217 -0.0507,-0.087 -0.0507,-0.18116 l 0,-3.76812 q 0,-0.0942 0.0507,-0.18116 0.0507,-0.087 0.13768,-0.15217 0.087,-0.0652 0.19565,-0.10145 0.11594,-0.0362 0.24638,-0.0362 l 2.00724,0 q 0.26087,0 0.44203,0.14492 0.18116,0.13769 0.18116,0.32609 l 0,2.3116 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path5659"
+                 inkscape:connector-curvature="0" />
+              <path
+                 ns5245954:connector-curvature="0"
+                 d="m 513.76228,620.21948 0.74637,1.38406 0,0.28986 -0.34782,0.32608 -0.7029,0 -0.53623,-1.08695 -0.53624,1.08695 -0.69565,0 -0.35507,-0.32608 0,-0.28261 0.65942,-1.37682 -0.52174,0 q -0.1087,-0.13043 -0.1087,-0.33333 l 0,-0.058 q 0.007,-0.26812 0.18841,-0.3913 l 0.42029,0 -0.63768,-1.43479 0,-0.2971 0.35507,-0.26087 0.69565,0 0.53624,1.05073 0.37681,-0.73913 0.28985,-0.33334 0.3116,0.0217 0.26087,0 0.34782,0.26087 0,0.2971 -0.74637,1.43479 0.57971,0 q 0.16666,0.12318 0.16666,0.40579 0,0.2971 -0.25362,0.36232 l -0.49275,0 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path5661"
+                 inkscape:connector-curvature="0" />
+              <path
+                 ns5245954:connector-curvature="0"
+                 d="m 520.78741,618.45137 0,-0.94203 -2.67391,0 q -0.13044,0 -0.24638,0.0362 -0.10869,0.0362 -0.19565,0.10145 -0.087,0.0652 -0.13768,0.15217 -0.0507,0.087 -0.0507,0.18116 l 0,3.76812 q 0,0.0942 0.0507,0.18116 0.0507,0.087 0.13768,0.15217 0.087,0.0652 0.19565,0.10145 0.11594,0.0362 0.24638,0.0362 l 2.02898,0 q 0.13044,0 0.24638,-0.0362 0.12319,-0.0362 0.21015,-0.10145 0.087,-0.0652 0.13768,-0.15217 0.0507,-0.087 0.0507,-0.18116 l 0,-1.45652 0.62319,0 0,-0.84783 -2.65942,0 0,-0.99275 2.03623,0 z m -2.03623,1.84058 0.76087,0 0,0.9855 -0.76087,0 0,-0.9855 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path5663"
+                 inkscape:connector-curvature="0" />
+              <path
+                 ns5245954:connector-curvature="0"
+                 d="m 527.56538,619.20499 -1.24638,0 0,-0.74638 -0.75362,0 0,0.98551 0.89855,0 0,0.84783 -0.89855,0 0,0.9855 0.75362,0 0,-0.75362 1.24638,0 0,1.22464 q 0,0.1884 -0.18116,0.33333 -0.18116,0.13768 -0.44203,0.13768 l -2.00725,0 q -0.13043,0 -0.24637,-0.0362 -0.1087,-0.0362 -0.19565,-0.10145 -0.087,-0.0652 -0.13769,-0.15217 -0.0507,-0.087 -0.0507,-0.18116 l 0,-3.76812 q 0,-0.0942 0.0507,-0.18116 0.0507,-0.087 0.13769,-0.15217 0.087,-0.0652 0.19565,-0.10145 0.11594,-0.0362 0.24637,-0.0362 l 2.00725,0 q 0.26087,0 0.44203,0.14492 0.18116,0.13769 0.18116,0.32609 l 0,1.22464 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path5665"
+                 inkscape:connector-curvature="0" />
+              <path
+                 ns5245954:connector-curvature="0"
+                 d="m 529.41502,621.27745 0.75362,0 0,-0.75362 1.24638,0 0,1.69565 -3.26087,0 0,-4.71014 1.26087,0 0,3.76811 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path5667"
+                 inkscape:connector-curvature="0" />
+              <path
+                 ns5245954:connector-curvature="0"
+                 d="m 533.25016,620.80644 0.74638,0 0,-2.54348 -0.74638,0 0,2.54348 z m -1.26087,-3.3116 3.27537,0 0,4.72464 -1.2029,0 0,-0.47826 -0.8116,0 0,0.47826 -1.26087,0 0,-4.72464 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path5669"
+                 inkscape:connector-curvature="0" />
+              <path
+                 ns5245954:connector-curvature="0"
+                 d="m 535.85342,617.50934 0,0.86956 1.93479,2.89855 -0.67392,0 0,-0.75362 -1.26087,0 0,1.69565 3.26087,0 0,-0.86956 -1.92753,-2.89131 0.68116,0 0,0.74638 1.24637,0 0,-1.69565 -3.26087,0 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path5671"
+                 inkscape:connector-curvature="0" />
+              <path
+                 ns5245954:connector-curvature="0"
+                 d="m 541.94219,618.46586 0,3.75362 -1.22463,0 0,-3.75362 -0.95653,0 0,-0.95652 3.15218,0 0,0.95652 -0.97102,0 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path5673"
+                 inkscape:connector-curvature="0" />
+              <path
+                 ns5245954:connector-curvature="0"
+                 d="m 544.58928,617.50934 0,4.71014 -1.08696,0 0,-4.71014 1.08696,0 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path5675"
+                 inkscape:connector-curvature="0" />
+              <path
+                 ns5245954:connector-curvature="0"
+                 d="m 548.41287,619.20499 -1.24638,0 0,-0.74638 -0.75362,0 0,2.81884 0.75362,0 0,-0.75362 1.24638,0 0,1.22464 q 0,0.1884 -0.18116,0.33333 -0.18116,0.13768 -0.44203,0.13768 l -2.00725,0 q -0.13043,0 -0.24637,-0.0362 -0.1087,-0.0362 -0.19565,-0.10145 -0.087,-0.0652 -0.13769,-0.15217 -0.0507,-0.087 -0.0507,-0.18116 l 0,-3.76812 q 0,-0.0942 0.0507,-0.18116 0.0507,-0.087 0.13769,-0.15217 0.087,-0.0652 0.19565,-0.10145 0.11594,-0.0362 0.24637,-0.0362 l 2.00725,0 q 0.26087,0 0.44203,0.14492 0.18116,0.13769 0.18116,0.32609 l 0,1.22464 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:7.24637842px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.03032364;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path5677"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           transform="matrix(1.25,0,0,1.25,-0.3277,0.28806971)"
+           id="g7969"
+           style="stroke:#0000ff;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path7971-0"
+             style="fill:none;stroke:#0000ff;stroke-width:0.80000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7.58995819;stroke-dasharray:none;stroke-opacity:1"
+             d="m 364.199,386.848 c 0,0 6.977,-1.996 10.324,-4.262 3.555,-2.406 9.723,-10.148 9.723,-10.148"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(1.25,0,0,1.25,-0.3277,0.28806971)"
+           id="g7973"
+           style="stroke:#0000ff;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path7975-4"
+             style="fill:none;stroke:#0000ff;stroke-width:0.80000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7.58995819;stroke-dasharray:none;stroke-opacity:1"
+             d="m 364.543,383.188 -8.547,5.652 10.172,1.23 c -1.969,-1.679 -2.625,-4.461 -1.625,-6.882 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(-1.25,0.3894625,-0.3894625,-1.25,-0.3277,0.28806971)"
+           id="g7977"
+           style="stroke:#0000ff;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path7979-7"
+             style="fill:none;stroke:#0000ff;stroke-width:0.76378602;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7.58995819;stroke-dasharray:none;stroke-opacity:1"
+             d="m -482.365,-919.431 c 0,0 6.665,-1.908 9.854,-4.07 3.4,-2.297 9.289,-9.689 9.289,-9.689"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(-1.25,0.3894625,-0.3894625,-1.25,-0.3277,0.28806971)"
+           id="g7981"
+           style="stroke:#0000ff;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path7983-2"
+             style="fill:none;stroke:#0000ff;stroke-width:0.76378602;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7.58995819;stroke-dasharray:none;stroke-opacity:1"
+             d="m -482.034,-922.926 -8.161,5.395 9.712,1.175 c -1.883,-1.603 -2.505,-4.258 -1.551,-6.57 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <path
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7.58995819;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           d="m 474.50977,963.61133 -0.75,0.6582 c 0,0 1.83817,2.09583 3.96484,4.79883 2.12667,2.703 4.54187,6.02983 5.65625,8.38281 2.1117,4.45129 4.10351,14.07422 4.10352,14.07422 l 0.97851,-0.20117 c 0,0 -1.93638,-9.57403 -4.17969,-14.30274 l 0.002,0 c -1.19563,-2.52452 -3.63081,-5.8465 -5.77539,-8.57226 -2.14458,-2.72577 -4,-4.83789 -4,-4.83789 z"
+           id="path7985-9"
+           inkscape:connector-curvature="0" />
+        <path
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7.58995819;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           d="m 465.39648,955.71094 7.04883,14.16406 0.20313,-1.65039 c 0.36957,-2.99585 2.66022,-5.41927 5.66992,-6.00391 l 1.59961,-0.3125 -1.5,-0.63867 -13.02149,-5.55859 z m 2.10547,1.98633 9.36719,3.99804 c -2.34544,0.87684 -4.10906,2.73905 -4.83398,5.11133 l -4.53321,-9.10937 z"
+           id="path7987-7"
+           inkscape:connector-curvature="0" />
+        <path
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           d="m 888.1582,889.71094 c -0.24145,0 -0.40611,0.14543 -0.45508,0.37304 l 0,0.004 -0.75781,4.06836 0,0.004 c 0.002,-0.0139 -0.002,0.005 -0.0117,0.0156 -0.009,0.0105 -0.0203,0.009 0.006,0.004 l -0.0234,0.004 -2.7461,1.13477 -0.006,0.002 c 0.004,-0.002 -0.0726,-0.0142 -0.0488,0.004 l -0.004,-0.004 -3.40625,-2.33984 -0.002,0 c -0.0938,-0.0618 -0.19396,-0.0822 -0.29687,-0.0723 -0.10291,0.01 -0.21749,0.0558 -0.29883,0.15625 l 0.0176,-0.0195 -2.86914,2.85938 -0.002,0.004 c -0.15077,0.16184 -0.18217,0.39624 -0.0371,0.58985 l 2.26758,3.30664 c 0.006,0.0109 -0.002,0.10151 0.0156,0.0684 l -0.004,0.01 -1.21484,2.82813 -0.002,0.008 c 0.008,-0.022 -10e-4,10e-4 -0.0176,0.0156 -0.0165,0.0142 -0.0407,0.0207 -0.0254,0.0176 l -3.93555,0.72852 -0.008,0.002 c -0.2142,0.0546 -0.35352,0.24295 -0.35352,0.45703 l 0,4.03907 c 0,0.2147 0.14187,0.41497 0.36524,0.46093 l 0.002,0 3.82422,0.70508 c -0.016,-0.004 0.0536,0.0515 0.0606,0.0605 2.2e-4,2.9e-4 0.002,0.002 0.002,0.002 l 1.1875,2.99024 0.004,0.01 c -0.005,-0.0108 -0.0154,0.0766 0.002,0.0508 l -2.18164,3.16992 c -0.13842,0.19738 -0.10067,0.41888 0.041,0.58204 l 0.006,0.006 2.86914,2.86329 c 0.0865,0.0905 0.19322,0.12553 0.29102,0.13281 0.0978,0.007 0.19432,-0.0106 0.28906,-0.0723 l 0.004,-0.002 3.12695,-2.14258 0.006,-0.006 c -0.0144,0.011 -0.004,0.003 0.01,0.002 0.0136,-8.5e-4 0.0261,0.008 0.01,-0.002 l 0.004,0.002 1.3789,0.74414 0.002,0.002 c 0.21445,0.10966 0.47226,-0.01 0.5664,-0.19922 l 0.004,-0.008 2.82812,-6.84375 0,-0.002 c 0.0498,-0.11247 0.0449,-0.21965 0.0176,-0.31446 -0.0274,-0.0954 -0.0772,-0.18733 -0.17968,-0.25586 l -0.006,-0.004 -0.35547,-0.21094 -0.002,0 c -0.0367,-0.021 -0.11677,-0.0833 -0.18164,-0.13867 l -0.0117,-0.01 -0.0156,-0.01 c -1.17221,-0.7575 -1.94531,-2.05845 -1.94531,-3.55469 0,-2.33648 1.88286,-4.21875 4.21289,-4.21875 2.33667,0 4.22656,1.88285 4.22656,4.21875 0,1.49572 -0.77775,2.79694 -1.95508,3.55469 l -0.0215,0.0137 -0.0195,0.0195 c -0.039,0.039 -0.12021,0.10052 -0.16016,0.12305 l -0.004,0.002 -0.34179,0.20703 c -0.10824,0.0631 -0.1676,0.15749 -0.19922,0.25391 -0.0316,0.0964 -0.0384,0.20353 0.004,0.31445 l 0,0.002 2.83594,6.82422 c 0.0727,0.2331 0.36168,0.3421 0.57227,0.23633 l 0.002,-0.002 1.39258,-0.7461 0.006,-0.004 c -0.0379,0.0235 0.0245,0.0166 0.0176,0.0117 l 0.002,0 3.12305,2.14453 0.006,0.004 c 0.17908,0.10702 0.4055,0.0998 0.57226,-0.0566 l 0.002,-0.002 2.87304,-2.87305 0.008,-0.008 c 0.13634,-0.16272 0.17333,-0.38892 0.0273,-0.58398 l -2.16992,-3.16993 -0.002,-0.004 c 0.0193,0.0258 0.005,-0.0585 0.002,-0.0508 l 0.002,-0.004 1.19922,-2.99414 c -10e-4,0.004 0.0683,-0.0575 0.0566,-0.0547 l 3.82226,-0.70508 0.004,-0.002 c 0.22022,-0.0468 0.36914,-0.23093 0.36914,-0.45898 l 0,-4.03907 c 0,-0.2293 -0.14729,-0.39931 -0.35742,-0.45507 l -0.0625,0.23046 0.0449,-0.23632 -3.92578,-0.72657 c 0.0139,0.003 -0.009,-0.004 -0.0273,-0.0195 -0.0183,-0.0154 -0.0324,-0.0392 -0.0274,-0.0273 l -1.20508,-2.82227 -0.006,-0.01 c 0.0177,0.0331 0.009,-0.0574 0.0156,-0.0684 l 2.26953,-3.30664 0,-0.002 c 0.14326,-0.19313 0.11287,-0.42439 -0.0352,-0.58593 l -0.004,-0.004 -2.85938,-2.85352 c -0.16085,-0.17363 -0.40568,-0.18821 -0.58398,-0.0762 l -0.004,0.004 -3.40429,2.33594 -0.002,0.002 c 0.009,-0.006 -0.0684,-0.004 -0.0488,0.006 l -0.01,-0.004 -2.74609,-1.13672 -0.0215,-0.004 c 0.0267,0.006 0.0145,0.006 0.004,-0.006 -0.0106,-0.0118 -0.0176,-0.0316 -0.0156,-0.0215 l -0.75586,-4.05273 c -0.0363,-0.24004 -0.21906,-0.38867 -0.45703,-0.38867 l -4.04297,0 z m 0.0352,0.4707 0,0.008 c -6e-4,0.003 -0.002,-3.1e-4 -0.002,0.002 l 0.002,-0.01 z m -0.006,0.0293 3.98242,0 0.75196,4.03515 0.002,0 c 0.0206,0.1076 0.0688,0.19043 0.13281,0.26172 0.064,0.0713 0.14396,0.13441 0.26367,0.16016 l -0.043,-0.0137 2.69727,1.11523 c 0.19459,0.10008 0.38751,0.0809 0.56445,-0.043 l 3.36328,-2.31054 2.81836,2.8125 -2.27343,3.31445 -0.004,0.008 c -0.10161,0.17405 -0.13107,0.35849 -0.0254,0.55664 l -0.01,-0.0195 1.20118,2.8125 c 0.04,0.0943 0.0968,0.15814 0.16406,0.21484 0.0672,0.0567 0.14508,0.10512 0.25195,0.12696 l 0.002,0 3.89844,0.72265 0,3.98828 -3.80664,0.70313 -0.008,0.002 c -0.20666,0.0502 -0.33085,0.17571 -0.40235,0.35547 l -1.1914,2.98047 c -0.0814,0.18274 -0.0845,0.36895 0.0527,0.55274 l 2.15039,3.14648 -2.81445,2.81445 -3.08789,-2.12109 c -6e-4,-4.2e-4 -10e-4,4.2e-4 -0.002,0 -0.17389,-0.12179 -0.37318,-0.14841 -0.56836,-0.0273 l -1.27539,0.68554 -2.79297,-6.72265 0.3164,-0.19141 -0.008,0.002 c 0.0851,-0.048 0.16264,-0.11253 0.23438,-0.17969 1.30806,-0.84566 2.17773,-2.30082 2.17773,-3.96679 0,-2.60651 -2.12063,-4.71875 -4.72656,-4.71875 -2.59998,0 -4.71289,2.11283 -4.71289,4.71875 0,1.66795 0.86539,3.12731 2.17187,3.97265 7.9e-4,5.1e-4 10e-4,10e-4 0.002,0.002 0.0678,0.0575 0.143,0.12059 0.23242,0.17187 l 0.30273,0.18164 -2.78125,6.73243 -1.27929,-0.68946 c -0.0988,-0.0575 -0.19769,-0.0704 -0.29297,-0.0645 -0.0953,0.006 -0.1918,0.0296 -0.28321,0.0996 l -3.08008,2.11133 -2.82031,-2.81446 2.16797,-3.15039 0.002,-0.002 c 0.12293,-0.18253 0.12171,-0.36662 0.0293,-0.55273 l -1.17969,-2.97461 -0.002,-0.004 c -0.0747,-0.1692 -0.19191,-0.29347 -0.39648,-0.3457 l -0.008,-0.004 -3.80664,-0.70117 0,-3.99219 3.89453,-0.7207 0.002,0 c 0.10785,-0.0218 0.18447,-0.0708 0.25195,-0.12891 0.0675,-0.0581 0.12534,-0.12259 0.16211,-0.22656 l 1.19141,-2.7793 c 0.10568,-0.19815 0.0762,-0.38259 -0.0254,-0.55664 l -0.004,-0.008 -2.27344,-3.3125 2.82031,-2.81055 3.35547,2.30274 c 0.17883,0.13567 0.37469,0.1406 0.56641,0.0488 l 2.70508,-1.11718 -0.043,0.0137 c 0.11985,-0.0256 0.20148,-0.0895 0.26562,-0.16211 0.0638,-0.0722 0.11344,-0.1571 0.13086,-0.26758 l 0.74805,-4.02734 z m 3.97852,20.07812 0.004,0.006 c 0.003,0.007 10e-4,0.003 0.002,0.006 l -0.006,-0.0117 z"
+           id="path7991-7"
+           inkscape:connector-curvature="0" />
+        <path
+           ns5245954:connector-curvature="0"
+           id="path7993-7"
+           style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.1164525;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 877.21823,942.63756 1.42143,0 0,-4.81479 c 0,-1.73991 -1.19548,-2.31915 -2.93736,-2.31915 -1.05169,0 -1.83833,0.27327 -2.38274,1.03525 l 1.11545,0.84432 c 0.24846,-0.4026 0.60176,-0.54639 1.33105,-0.54639 1.01883,0 1.45217,0.23204 1.45217,0.90577 l 0,0.73948 -1.96569,0 c -1.51593,0 -2.28629,0.95524 -2.28629,2.08499 0,1.22013 0.91415,2.15055 2.48759,2.15055 0.95507,0 1.44395,-0.2156 1.73365,-0.70661 l 0.0313,0 0,0.62658 z m 0,-2.47115 c 0,1.0908 -0.40047,1.22835 -1.58774,1.22835 -0.95523,0 -1.33319,-0.42512 -1.33319,-0.8997 0,-0.51353 0.38617,-0.84218 1.22835,-0.84218 l 1.69258,0 0,0.51353 z"
+           inkscape:connector-curvature="0" />
+        <path
+           ns5245954:connector-curvature="0"
+           id="path7995-6"
+           style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.1164525;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 880.19468,942.63756 1.42144,0 0,-4.24375 c 0,-1.02705 0.69018,-1.47698 1.38034,-1.47698 0.35331,0 0.58535,0.11344 0.93043,0.36974 l 1.01882,-1.23656 c -0.4251,-0.33687 -0.89968,-0.54639 -1.46858,-0.54639 -0.75394,0 -1.38858,0.27327 -1.84457,0.83609 l -0.0164,0 0,-0.75393 -1.4216,0 0,7.05178 z"
+           inkscape:connector-curvature="0" />
+        <path
+           ns5245954:connector-curvature="0"
+           id="path7997-95"
+           style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.1164525;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 889.18947,942.63756 1.42144,0 0,-9.89251 -1.42144,0 0,3.59466 c -0.52995,-0.5053 -1.09063,-0.83609 -1.81992,-0.83609 -0.86682,0 -1.48503,0.38616 -1.88565,0.92433 -0.3944,0.48888 -0.50532,0.95524 -0.50532,2.67854 0,1.74188 0.11176,2.20002 0.50532,2.6889 0.40062,0.53817 1.01883,0.9222 1.88565,0.9222 0.72929,0 1.37838,-0.32865 1.81992,-0.80932 l 0,0.72929 z m -1.38856,-5.72073 c 1.31675,0 1.38856,1.17083 1.38856,2.18966 0,1.02705 -0.0724,2.20002 -1.38856,2.20002 -1.32283,0 -1.39464,-1.09903 -1.39464,-2.20002 0,-1.09064 0.0724,-2.18966 1.39464,-2.18966"
+           inkscape:connector-curvature="0" />
+        <path
+           ns5245954:connector-curvature="0"
+           id="path7999-2"
+           style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.1164525;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 897.84756,942.63756 1.25086,0 2.25539,-7.05178 -1.49948,0 -1.35571,4.95036 -0.0247,0 -1.59808,-4.95036 -1.02705,0 -1.60416,4.95036 -0.023,0 -1.34946,-4.95036 -1.49948,0 2.25325,7.05178 1.24479,0 1.47697,-4.94215 0.0313,0 1.46876,4.94215 z"
+           inkscape:connector-curvature="0" />
+        <path
+           ns5245954:connector-curvature="0"
+           id="path8001-1"
+           style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.1164525;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 905.72706,942.63756 1.40483,0 0,-4.81479 c 0,-1.73991 -1.18102,-2.31915 -2.92897,-2.31915 -1.05991,0 -1.8385,0.27327 -2.37469,1.03525 l 1.11545,0.84432 c 0.24847,-0.4026 0.59356,-0.54639 1.33105,-0.54639 1.01062,0 1.45233,0.23204 1.45233,0.90577 l 0,0.73948 -1.96585,0 c -1.51593,0 -2.28612,0.95524 -2.28612,2.08499 0,1.22013 0.91398,2.15055 2.4792,2.15055 0.95507,0 1.45233,-0.2156 1.73974,-0.70661 l 0.0328,0 0,0.62658 z m 0,-2.47115 c 0,1.0908 -0.40063,1.22835 -1.5879,1.22835 -0.96329,0 -1.34123,-0.42512 -1.34123,-0.8997 0,-0.51353 0.39422,-0.84218 1.22834,-0.84218 l 1.70063,0 0,0.51353 z"
+           inkscape:connector-curvature="0" />
+        <path
+           ns5245954:connector-curvature="0"
+           id="path8003-4"
+           style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.1164525;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 908.70336,942.63756 1.42143,0 0,-4.24375 c 0,-1.02705 0.66553,-1.47698 1.36392,-1.47698 0.36151,0 0.60193,0.11344 0.93881,0.36974 l 1.02703,-1.23656 c -0.42527,-0.33687 -0.90806,-0.54639 -1.46875,-0.54639 -0.75377,0 -1.39678,0.27327 -1.84457,0.83609 l -0.0164,0 0,-0.75393 -1.42143,0 0,7.05178 z"
+           inkscape:connector-curvature="0" />
+        <path
+           ns5245954:connector-curvature="0"
+           id="path8005-2"
+           style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.1164525;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 919.2964,939.65288 0,-1.17083 c 0,-1.82189 -1.34962,-2.97843 -2.90662,-2.97843 -1.36392,0 -2.91271,0.88326 -2.91271,3.63574 0,2.87984 1.68649,3.57823 3.13866,3.57823 0.9388,0 1.85278,-0.32865 2.54296,-1.13173 l -1.03526,-0.87306 c -0.4169,0.42527 -0.99418,0.68196 -1.54057,0.68196 -0.96953,0 -1.67614,-0.60177 -1.67614,-1.74188 l 4.38968,0 z m -4.38968,-1.17083 c 0.0164,-1.06813 0.64909,-1.64525 1.48306,-1.64525 0.8361,0 1.4543,0.57712 1.48519,1.64525 l -2.96825,0 z"
+           inkscape:connector-curvature="0" />
+        <path
+           ns5245954:connector-curvature="0"
+           id="path8007-89"
+           style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.1164525;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 858.89161,928.14585 c 0,1.70293 0.24862,2.34381 0.85039,3.00112 0.42528,0.49084 1.16475,1.01259 2.37666,1.01259 1.20978,0 1.93283,-0.52175 2.36632,-1.01259 0.60177,-0.65731 0.8504,-1.29819 0.8504,-3.00112 0,-1.67613 -0.24863,-2.31702 -0.8504,-2.99289 -0.43349,-0.46406 -1.15654,-0.99401 -2.36632,-0.99401 -1.21191,0 -1.95138,0.52995 -2.37666,0.99401 -0.60177,0.67587 -0.85039,1.31676 -0.85039,2.99289 m 4.87034,0.0247 c 0,1.12368 -0.0969,1.42145 -0.37598,1.84672 -0.24026,0.32043 -0.73127,0.56891 -1.26731,0.56891 -0.54638,0 -1.02703,-0.24848 -1.26942,-0.56891 -0.27936,-0.42527 -0.3842,-0.72304 -0.3842,-1.87137 0,-1.12152 0.10517,-1.42767 0.3842,-1.84457 0.24239,-0.31222 0.72304,-0.5689 1.26942,-0.5689 0.53604,0 1.02705,0.25668 1.26731,0.5689 0.27935,0.4169 0.37598,0.72305 0.37598,1.86922"
+           inkscape:connector-curvature="0" />
+        <path
+           ns5245954:connector-curvature="0"
+           id="path8009-7"
+           style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.1164525;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 878.74236,928.50737 0,-1.17083 c 0,-1.81384 -1.3557,-2.96808 -2.91271,-2.96808 -1.36392,0 -2.9127,0.88112 -2.9127,3.62539 0,2.89627 1.69471,3.59467 3.13044,3.59467 0.95524,0 1.86101,-0.33687 2.55118,-1.15441 l -1.03525,-0.86682 c -0.40869,0.44171 -1.0024,0.69838 -1.54058,0.69838 -0.9715,0 -1.67614,-0.60176 -1.67614,-1.7583 l 4.39576,0 z m -4.39576,-1.17083 c 0.023,-1.07635 0.64088,-1.62898 1.48305,-1.62898 0.84432,0 1.45234,0.55263 1.48519,1.62898 l -2.96824,0 z"
+           inkscape:connector-curvature="0" />
+        <path
+           ns5245954:connector-curvature="0"
+           id="path8011-76"
+           style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.1164525;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 879.94606,931.50027 1.42964,0 0,-4.19659 c 0,-0.96953 0.58551,-1.51592 1.39481,-1.51592 0.79486,0 1.39679,0.54639 1.39679,1.51592 l 0,4.19659 1.41108,0 0,-4.69369 c 0,-1.58773 -1.25086,-2.43812 -2.34166,-2.43812 -0.76199,0 -1.38857,0.27098 -1.83833,0.83396 l -0.023,0 0,-0.75393 -1.42965,0 0,7.05178 z"
+           inkscape:connector-curvature="0" />
+        <path
+           ns5245954:connector-curvature="0"
+           id="path8013-2"
+           style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.1164525;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 889.41542,930.32122 c 0.90595,0.84201 1.95764,1.2673 3.10366,1.2673 1.63719,0 2.92109,-0.8011 2.92109,-2.17324 0,-1.11529 -0.59372,-2.01497 -2.04589,-2.1116 l -1.17082,-0.0888 c -0.70661,-0.0558 -0.93059,-0.35938 -0.93059,-0.66553 0,-0.48066 0.304,-0.84217 1.21799,-0.84217 0.76429,0 1.32498,0.24862 1.87958,0.64909 l 0.88128,-1.02705 c -0.69855,-0.58533 -1.5243,-0.96116 -2.76086,-0.96116 -1.49948,0 -2.63121,0.72912 -2.63121,2.16502 0,1.21175 0.85862,1.91031 2.0232,2.00677 l 1.25103,0.11344 c 0.48887,0.0394 0.8586,0.19095 0.8586,0.68804 0,0.60194 -0.57728,0.90792 -1.38856,0.90792 -0.93864,0 -1.61254,-0.30598 -2.22252,-0.90792 l -0.98598,0.97988 z"
+           inkscape:connector-curvature="0" />
+        <path
+           ns5245954:connector-curvature="0"
+           id="path8015-1"
+           style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.1164525;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 896.24323,927.96312 c 0,1.54058 0.22398,2.11769 0.76215,2.7114 0.39225,0.44977 1.04348,0.914 2.15055,0.914 1.09081,0 1.74188,-0.46423 2.13428,-0.914 0.54639,-0.59371 0.77021,-1.17082 0.77021,-2.7114 0,-1.50983 -0.22382,-2.08696 -0.77021,-2.69711 -0.3924,-0.42511 -1.04347,-0.89755 -2.13428,-0.89755 -1.10707,0 -1.7583,0.47244 -2.15055,0.89755 -0.53817,0.61015 -0.76215,1.18728 -0.76215,2.69711 m 4.39576,0.023 c 0,1.01061 -0.0805,1.28389 -0.35133,1.67827 -0.20936,0.27936 -0.65107,0.51353 -1.13173,0.51353 -0.49708,0 -0.93058,-0.23417 -1.14815,-0.51353 -0.25684,-0.39438 -0.34509,-0.66766 -0.34509,-1.70078 0,-1.01276 0.0888,-1.28389 0.34509,-1.66185 0.21757,-0.28955 0.65107,-0.51352 1.14815,-0.51352 0.48066,0 0.92222,0.22397 1.13173,0.51352 0.27114,0.37796 0.35133,0.64909 0.35133,1.68436"
+           inkscape:connector-curvature="0" />
+        <path
+           ns5245954:connector-curvature="0"
+           id="path8017-05"
+           style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.1164525;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 903.27233,929.15039 c 0,1.57951 1.25103,2.43813 2.36632,2.43813 0.73125,0 1.36392,-0.28758 1.81385,-0.84219 l 0.0394,0 0,0.75394 1.40499,0 0,-7.05178 -1.40499,0 0,4.2048 c 0,0.95311 -0.60802,1.52415 -1.38644,1.52415 -0.82789,0 -1.42143,-0.57104 -1.42143,-1.52415 l 0,-4.2048 -1.41125,0 0,4.7019 z"
+           inkscape:connector-curvature="0" />
+        <path
+           ns5245954:connector-curvature="0"
+           id="path8019-3"
+           style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.1164525;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 910.45345,931.50027 1.41946,0 0,-4.22732 c 0,-1.02705 0.68195,-1.48519 1.38034,-1.48519 0.36153,0 0.60177,0.0888 0.93042,0.34509 l 1.03527,-1.22835 c -0.44154,-0.33687 -0.91399,-0.53604 -1.48306,-0.53604 -0.74769,0 -1.38856,0.27098 -1.82189,0.83396 l -0.0411,0 0,-0.75393 -1.41947,0 0,7.05178 z"
+           inkscape:connector-curvature="0" />
+        <path
+           ns5245954:connector-curvature="0"
+           id="path8021-5"
+           style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.1164525;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 919.72775,929.4235 c -0.35132,0.43957 -0.85055,0.75394 -1.41946,0.75394 -1.16261,0 -1.83635,-0.66767 -1.83635,-2.20002 0,-1.54057 0.67374,-2.18966 1.83635,-2.18966 0.56891,0 1.06814,0.304 1.41946,0.73749 l 1.04349,-0.9388 c -0.60193,-0.71269 -1.45234,-1.21799 -2.52654,-1.21799 -1.62897,0 -3.20241,1.02705 -3.20241,3.60896 0,2.58405 1.57344,3.6111 3.20241,3.6111 1.0742,0 1.92461,-0.51353 2.52654,-1.23443 l -1.04349,-0.93059 z"
+           inkscape:connector-curvature="0" />
+        <path
+           ns5245954:connector-curvature="0"
+           id="path8023-5"
+           style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.1164525;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 926.94994,928.50737 0,-1.17083 c 0,-1.81384 -1.35569,-2.96808 -2.91269,-2.96808 -1.36392,0 -2.90449,0.88112 -2.90449,3.62539 0,2.89627 1.67614,3.59467 3.13651,3.59467 0.93881,0 1.84672,-0.33687 2.54511,-1.15441 l -1.03526,-0.86682 c -0.41707,0.44171 -1.00453,0.69838 -1.54879,0.69838 -0.97167,0 -1.67007,-0.60176 -1.67007,-1.7583 l 4.38968,0 z m -4.38968,-1.17083 c 0.0247,-1.07635 0.64302,-1.62898 1.47699,-1.62898 0.85039,0 1.45215,0.55263 1.49324,1.62898 l -2.97023,0 z"
+           inkscape:connector-curvature="0" />
+        <path
+           ns5245954:connector-curvature="0"
+           id="path8025"
+           style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.1164525;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 869.14564,930.17744 c 1.3414,0 1.405,-1.10725 1.405,-2.1918 0,-1.10708 -0.0641,-2.19788 -1.405,-2.19788 -1.32284,0 -1.38643,1.16261 -1.38643,2.19788 0,1.01061 0.0641,2.1918 1.38643,2.1918 m -2.81608,12.46012 0,-18.18907 1.42965,0 0,0.73734 c 0.44155,-0.4805 1.09886,-0.81737 1.81368,-0.81737 0.86486,0 1.49127,0.38403 1.89191,0.91399 0.39438,0.50531 0.49906,0.96328 0.49906,2.70319 0,1.72543 -0.10518,2.1918 -0.49906,2.67245 -0.40064,0.54639 -1.02705,0.93043 -1.89191,0.93043 -0.71482,0 -1.29194,-0.33687 -1.81368,-0.84219 l -0.0164,5.59338 c 0.46423,-0.56282 1.11529,-0.83609 1.861,-0.83609 1.10708,0 2.34365,0.85252 2.34365,2.44848 l 0,4.68546 -1.405,0 0,-4.1966 c 0,-0.9715 -0.60999,-1.52413 -1.38857,-1.52413 -0.81753,0 -1.41108,0.55263 -1.41108,1.52413 l 0,4.1966 -1.4216,0 z"
+           inkscape:connector-curvature="0" />
+        <g
+           transform="matrix(1.25,0,0,1.25,-0.3277,0.28806971)"
+           id="g8027"
+           style="stroke:#0000ff;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path8029"
+             style="fill:none;stroke:#0000ff;stroke-width:0.80000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7.58995819;stroke-dasharray:none;stroke-opacity:1"
+             d="m 766.496,375.891 c 0,0 4.961,6.234 8.285,8.574 3.528,2.488 12.219,5.015 12.219,5.015"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(1.25,0,0,1.25,-0.3277,0.28806971)"
+           id="g8031"
+           style="stroke:#0000ff;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path8033"
+             style="fill:none;stroke:#0000ff;stroke-width:0.80000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7.58995819;stroke-dasharray:none;stroke-opacity:1"
+             d="m 785.008,392.695 10.18,-1.16 -8.5,-5.711 c 1,2.395 0.308,5.164 -1.68,6.871 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(1.25,0,0,1.25,-0.3277,0.28806971)"
+           id="g8059"
+           style="stroke:#0000ff;stroke-width:0.05669291;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path8061"
+             style="fill:none;stroke:#0000ff;stroke-width:0.05669291;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 446.383,45.055 c 0.187,-0.039 0.281,-0.289 0.281,-0.75 0,-0.457 -0.074,-0.758 -0.219,-0.907 l -1.515,0 1.734,-4.421 0,-0.688 -0.609,-0.609 -0.453,0 -0.516,-0.032 -0.516,0.75 -1.062,2.782 -1.328,-3.5 -1.203,0 -0.61,0.609 0,0.688 1.469,4.421 -1.188,0 c -0.148,0.125 -0.226,0.414 -0.234,0.86 l 0,0.156 c 0,0.336 0.039,0.574 0.125,0.719 l 1.375,0 -1.547,4.25 0,0.687 0.61,0.75 1.203,0 1.328,-3.64 1.344,3.64 1.203,0 0.609,-0.75 0,-0.687 -1.734,-4.328 1.453,0 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(1.25,0,0,1.25,-0.3277,0.28806971)"
+           id="g8063"
+           style="stroke:#0000ff;stroke-width:0.05669291;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path8065"
+             style="fill:none;stroke:#0000ff;stroke-width:0.05669291;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 452.91,40.023 2.078,0 0,-2.203 -6.25,0 0,2.203 2.078,0 0,10.797 2.094,0 0,-10.797 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(1.25,0,0,1.25,-0.3277,0.28806971)"
+           id="g8067"
+           style="stroke:#0000ff;stroke-width:0.05669291;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path8069"
+             style="fill:none;stroke:#0000ff;stroke-width:0.05669291;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 463.395,49.742 c 0,0.305 -0.106,0.559 -0.313,0.766 -0.211,0.211 -0.465,0.312 -0.766,0.312 l -4.312,0 c -0.305,0 -0.559,-0.101 -0.766,-0.312 -0.211,-0.207 -0.312,-0.461 -0.312,-0.766 l 0,-10.844 c 0,-0.289 0.101,-0.539 0.312,-0.75 0.207,-0.218 0.461,-0.328 0.766,-0.328 l 4.312,0 c 0.301,0 0.555,0.11 0.766,0.328 0.207,0.211 0.313,0.461 0.313,0.75 l 0,3.266 -2.157,0 0,-2.156 -2.156,0 0,3.359 4.313,0 0,6.375 z m -2.157,-4.469 -2.156,0 0,3.375 2.156,0 0,-3.375 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(1.25,0,0,1.25,-0.3277,0.28806971)"
+           id="g8071"
+           style="stroke:#0000ff;stroke-width:0.05669291;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path8073"
+             style="fill:none;stroke:#0000ff;stroke-width:0.05669291;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 470.395,37.82 -3.875,0 c -0.368,0 -0.672,0.133 -0.922,0.391 -0.25,0.25 -0.375,0.555 -0.375,0.906 l 0,10.422 c 0,0.367 0.097,0.668 0.297,0.906 0.207,0.231 0.539,0.356 1,0.375 l 4.093,0 c 0.313,-0.05 0.567,-0.195 0.766,-0.437 0.207,-0.25 0.312,-0.531 0.312,-0.844 l 0,-10.422 c 0,-0.351 -0.125,-0.656 -0.375,-0.906 -0.25,-0.258 -0.558,-0.391 -0.921,-0.391 z m -3.016,10.86 0,-8.672 2.156,0 0,8.672 -2.156,0 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(1.25,0,0,1.25,-0.3277,0.28806971)"
+           id="g8075"
+           style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.05669291;stroke-miterlimit:4;stroke-dasharray:none">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path8077"
+             style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.05669291;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 486.656,60.648 10.25,0 0,4.484 -10.25,0 0,-4.484 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(1.25,0,0,1.25,-0.3277,0.28806971)"
+           id="g8079"
+           style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.05669291;stroke-miterlimit:4;stroke-dasharray:none">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path8081"
+             style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.05669291;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 429.984,64.754 3.704,0 0,-3.188 -3.704,0 0,-5.765 -3.593,0 0,5.765 -3.829,0 0,3.188 3.704,0 0,5.062 3.718,0 0,-5.062 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(1.25,0,0,1.25,20.178399,-23.046457)"
+           id="g8091"
+           style="fill:#000000;fill-opacity:1;stroke:none">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path8093"
+             style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.05669291;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 732.684,432.742 -8.305,33.356 8.305,-8.149 8.601,8.602 -8.601,-33.809 z"
+             inkscape:connector-curvature="0" />
+          <path
+             inkscape:connector-curvature="0"
+             d="m 732.88044,439.55993 -5.19917,20.88185 5.19917,-5.10152 5.38448,5.3851 -5.38448,-21.16543 z"
+             style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.03549145;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="path5199"
+             ns5245954:connector-curvature="0" />
+          <path
+             ns5245954:connector-curvature="0"
+             id="path5201"
+             style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.01783694;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 732.92671,444.50192 -2.61294,10.49459 2.61294,-2.56387 2.70608,2.70639 -2.70608,-10.63711 z"
+             inkscape:connector-curvature="0" />
+          <path
+             ns5245954:connector-curvature="0"
+             id="path5203"
+             style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.03549145;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 384.9056,439.55993 -5.19917,20.88185 5.19917,-5.10152 5.38448,5.3851 -5.38448,-21.16543 z"
+             inkscape:connector-curvature="0" />
+          <path
+             inkscape:connector-curvature="0"
+             d="m 384.95187,444.50192 -2.61294,10.49459 2.61294,-2.56387 2.70608,2.70639 -2.70608,-10.63711 z"
+             style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.01783694;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="path5205"
+             ns5245954:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(1.25,0,0,1.25,-18.327702,-21.711933)"
+           id="g8095"
+           style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.05669291;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path8097"
+             style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.05669291;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 415.68,431.797 -8.301,33.359 8.301,-8.148 8.605,8.601 -8.605,-33.812 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(1.25,0,0,1.25,1.6723002,-10.318533)"
+           id="g8099"
+           style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.05669291;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path8101"
+             style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.05669291;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 654.434,214.074 -4.739,19.035 4.739,-4.648 4.91,4.91 -4.91,-19.297 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(1.25,0,0,1.25,-1.7419137,-10.318533)"
+           id="g8103"
+           style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.05669291;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path8105"
+             style="fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.05669291;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 498.242,214.047 -4.738,19.039 4.738,-4.652 4.91,4.914 -4.91,-19.301 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(1.25,-1.25,1.25,1.25,3.6723006,-3.7119308)"
+           id="g8107"
+           style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.02004397;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path8109"
+             style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.02004397;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m -167.191,577.168 0,-2.297 c 0,-0.219 -0.077,-0.396 -0.227,-0.539 -0.15,-0.15 -0.33,-0.225 -0.539,-0.227 l -3.047,0 c -0.209,0.002 -0.389,0.077 -0.539,0.227 -0.15,0.143 -0.227,0.32 -0.227,0.539 l 0,8.391 1.532,0 0,-3.922 1.375,0 0,-1.328 -1.375,0 0,-2.375 1.515,0 0,1.531 1.532,0 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(1.25,-1.25,1.25,1.25,3.6723006,-3.7119308)"
+           id="g8111"
+           style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.02004397;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path8113"
+             style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.02004397;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m -162.875,580.199 0,1.531 -1.516,0 0,-7.625 -1.531,0 0,9.157 4.578,0 0,-3.063 -1.531,0 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(1.25,-1.25,1.25,1.25,3.6723006,-3.7119308)"
+           id="g8115"
+           style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.02004397;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path8117"
+             style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.02004397;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m -156.895,575.855 -0.593,0 0,-1.75 -1.375,0 0,1.75 -0.672,0 c -0.125,0.075 -0.238,0.145 -0.336,0.211 -0.098,0.059 -0.176,0.114 -0.227,0.164 -0.115,0.116 -0.244,0.331 -0.39,0.641 l 0,3.5 c 0.103,0.209 0.215,0.371 0.328,0.484 0.115,0.116 0.291,0.256 0.531,0.422 l 0.703,0 0,1.985 1.485,0 0,-1.985 0.703,0 c 0.133,-0.062 0.246,-0.121 0.336,-0.179 0.088,-0.057 0.158,-0.123 0.211,-0.196 0.06,-0.072 0.113,-0.152 0.156,-0.234 0.041,-0.084 0.076,-0.182 0.109,-0.297 l 0,-3.609 c -0.144,-0.27 -0.271,-0.451 -0.375,-0.547 -0.062,-0.051 -0.14,-0.102 -0.234,-0.156 -0.094,-0.063 -0.215,-0.129 -0.36,-0.204 z m -2.078,4.157 0,-2.891 1.532,0 0,2.891 -1.532,0 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(1.25,-1.25,1.25,1.25,3.6723006,-3.7119308)"
+           id="g8119"
+           style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.02004397;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path8121"
+             style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.02004397;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m -153.859,574.105 3.047,0 c 0.208,0.002 0.388,0.077 0.539,0.227 0.15,0.143 0.226,0.32 0.226,0.539 l 0,8.391 -1.531,0 0,-7.641 -1.5,0 0,7.641 -1.547,0 0,-8.391 c 0,-0.219 0.076,-0.396 0.227,-0.539 0.15,-0.15 0.33,-0.225 0.539,-0.227 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(1.25,-1.25,1.25,1.25,3.6723006,-3.7119308)"
+           id="g8123"
+           style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.02004397;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+          <path
+             ns5245954:connector-curvature="0"
+             id="path8125"
+             style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.02004397;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m -144.201,577.17 0,-2.297 c 0,-0.219 -0.076,-0.396 -0.227,-0.539 -0.15,-0.15 -0.33,-0.225 -0.539,-0.227 l -3.047,0 c -0.209,0.002 -0.388,0.077 -0.539,0.227 -0.15,0.143 -0.226,0.32 -0.226,0.539 l 0,7.625 c 0,0.219 0.072,0.4 0.218,0.547 0.155,0.146 0.336,0.219 0.547,0.219 l 3.047,0 c 0.207,0 0.385,-0.073 0.531,-0.219 0.155,-0.147 0.235,-0.328 0.235,-0.547 l 0,-2.297 -1.531,0 0,1.531 -1.516,0 0,-2.375 3.047,0 0,-2.187 z m -1.531,0.844 -1.516,0 0,-2.375 1.516,0 0,2.375 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(1.25,-1.25,1.25,1.25,5.0423201,-3.4909599)"
+           id="g8127"
+           style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.04008794;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+          <g
+             id="text4168"
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:12.73832512px;line-height:125%;font-family:Pixacaism;-inkscape-font-specification:'Pixacaism Medium';letter-spacing:0px;word-spacing:0px;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.04008794;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+            <path
+               id="path5406"
+               style="font-weight:normal;font-family:Soviet;-inkscape-font-specification:Soviet;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.04008794;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m -139.36171,576.51239 0,-2.30563 c 0,-0.2123 0.0722,-0.39064 0.21655,-0.53501 0.15286,-0.15286 0.33544,-0.22929 0.54775,-0.22929 l 3.0572,0 c 0.2123,0 0.39063,0.0764 0.53501,0.22929 0.15285,0.14437 0.22928,0.32271 0.22929,0.53501 l 0,7.66847 c -1e-5,0.2123 -0.0764,0.39489 -0.22929,0.54774 -0.14438,0.14437 -0.32271,0.21656 -0.53501,0.21656 l -3.0572,0 c -0.21231,0 -0.39489,-0.0722 -0.54775,-0.21656 -0.14437,-0.15285 -0.21655,-0.33544 -0.21655,-0.54774 l 0,-2.30564 1.5286,0 0,1.5286 1.5286,0 0,-2.38207 -1.37574,0 0,-1.35026 1.37574,0 0,-2.38207 -1.5286,0 0,1.5286 -1.5286,0"
+               ns5245954:connector-curvature="0"
+               inkscape:connector-curvature="0" />
+            <path
+               id="path5408"
+               style="font-weight:normal;font-family:Soviet;-inkscape-font-specification:Soviet;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.04008794;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m -133.49014,580.34663 0,2.42028 2.16552,0 0,-2.42028 -2.16552,0"
+               ns5245954:connector-curvature="0"
+               inkscape:connector-curvature="0" />
+            <path
+               id="path5410"
+               style="font-weight:normal;font-family:Soviet;-inkscape-font-specification:Soviet;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.04008794;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m -126.18909,573.44246 -2.75148,0 c -0.25476,0 -0.47132,0.0892 -0.64965,0.2675 -0.17834,0.17835 -0.26751,0.3949 -0.26751,0.64966 l 0,7.37549 c 0,0.25476 0.0722,0.46707 0.21656,0.63691 0.14436,0.16135 0.3779,0.25052 0.7006,0.26751 l 2.90434,0 c 0.22079,-0.034 0.40338,-0.13588 0.54775,-0.30572 0.14436,-0.17834 0.21655,-0.37791 0.21655,-0.5987 l 0,-7.37549 c 0,-0.25476 -0.0892,-0.47131 -0.2675,-0.64966 -0.17835,-0.17833 -0.3949,-0.2675 -0.64966,-0.2675 m -2.14004,7.68121 0,-6.13988 1.5286,0 0,6.13988 -1.5286,0"
+               ns5245954:connector-curvature="0"
+               inkscape:connector-curvature="0" />
+          </g>
+        </g>
+        <g
+           id="g6944"
+           transform="matrix(0.96867884,0,0,0.96867884,1020.1427,14.488713)"
+           style="stroke:#0000ff;stroke-opacity:1">
+          <g
+             id="g8159"
+             transform="matrix(1.2084327,-1.2084327,1.2084327,1.2084327,-1018.1653,22.354473)"
+             style="stroke:#0000ff;stroke-opacity:1">
+            <g
+               id="text4172"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:23.35905266px;line-height:125%;font-family:Soviet;-inkscape-font-specification:Soviet;letter-spacing:0px;word-spacing:0px;fill:none;stroke:#0000ff;stroke-width:0.17174423;stroke-miterlimit:4">
+              <path
+                 id="path5413"
+                 style="font-size:7.0077157px;word-spacing:-0.74587125px;stroke:#0000ff"
+                 d="m -177.223,594.91205 -1.9061,0 0,5.05957 1.86405,0 c 0.22892,-0.0794 0.37374,-0.1495 0.43448,-0.21023 0.0607,-0.0607 0.13081,-0.20556 0.21023,-0.43448 l 0,-3.75614 c -0.0561,-0.21957 -0.1168,-0.37374 -0.1822,-0.46251 -0.0607,-0.0794 -0.20089,-0.14482 -0.42046,-0.19621 m -1.06518,0.84793 0.84093,0 0,3.36371 -0.84093,0 0,-3.36371"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path5415"
+                 style="font-size:7.0077157px;word-spacing:-0.74587125px;stroke:#0000ff"
+                 d="m -174.21713,597.8623 0.42046,0 c 0.11679,0 0.2149,-0.0397 0.29433,-0.11913 0.0841,-0.0841 0.12613,-0.18454 0.12613,-0.30134 l 0,-2.10932 c 0,-0.11679 -0.042,-0.2149 -0.12613,-0.29432 -0.0794,-0.0841 -0.17754,-0.12614 -0.29433,-0.12614 l -2.10231,0 0,5.05957 0.84092,0 0,-2.10932 0.84093,2.10932 0.84092,0 -0.84092,-2.10932 m 0,-0.84093 -0.84093,0 0,-1.26139 0.84093,0 0,1.26139"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path5417"
+                 style="font-size:7.0077157px;word-spacing:-0.74587125px;stroke:#0000ff"
+                 d="m -170.69269,595.87911 -0.33637,0 0,-0.96706 -0.75683,0 0,0.96706 -0.3644,0 c -0.0747,0.0374 -0.14016,0.0748 -0.19622,0.11213 -0.0514,0.0327 -0.0934,0.0654 -0.12614,0.0981 -0.0607,0.0607 -0.13081,0.17754 -0.21023,0.35039 l 0,1.93413 c 0.0561,0.11212 0.1168,0.20089 0.1822,0.26629 0.0654,0.0654 0.16351,0.14483 0.29433,0.23827 l 0.39243,0 0,1.0932 0.81289,0 0,-1.0932 0.39243,0 c 0.0747,-0.0374 0.13548,-0.0724 0.18221,-0.10512 0.0514,-0.0327 0.0934,-0.0677 0.12613,-0.10512 0.0327,-0.0374 0.0584,-0.0794 0.0771,-0.12614 0.0234,-0.0467 0.0444,-0.10277 0.0631,-0.16818 l 0,-1.99019 c -0.0794,-0.1495 -0.1495,-0.25228 -0.21023,-0.30834 -0.0327,-0.028 -0.0771,-0.0584 -0.13315,-0.0911 -0.0514,-0.0327 -0.11446,-0.0677 -0.18921,-0.10512 m -1.14926,2.29853 0,-1.59776 0.84092,0 0,1.59776 -0.84092,0"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path5419"
+                 style="font-size:7.0077157px;word-spacing:-0.74587125px;stroke:#0000ff"
+                 d="m -169.01828,594.91205 1.68185,0 c 0.11679,0 0.2149,0.0421 0.29432,0.12614 0.0841,0.0794 0.12614,0.17753 0.12614,0.29432 l 0,4.63911 -0.84092,0 0,-4.21865 -0.82691,0 0,4.21865 -0.85494,0 0,-4.63911 c -1e-5,-0.11679 0.0397,-0.2149 0.11913,-0.29432 0.0841,-0.0841 0.18453,-0.12614 0.30133,-0.12614"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path5421"
+                 style="font-size:7.0077157px;word-spacing:-0.74587125px;stroke:#0000ff"
+                 d="m -163.68585,596.60091 0,-1.2684 c 0,-0.11679 -0.0421,-0.2149 -0.12614,-0.29432 -0.0794,-0.0841 -0.17753,-0.12614 -0.29432,-0.12614 l -1.68185,0 c -0.1168,0 -0.21724,0.0421 -0.30133,0.12614 -0.0794,0.0794 -0.11914,0.17753 -0.11914,0.29432 l 0,4.21865 c 0,0.11679 0.0397,0.21724 0.11914,0.30133 0.0841,0.0794 0.18453,0.11913 0.30133,0.11913 l 1.68185,0 c 0.11679,0 0.2149,-0.0397 0.29432,-0.11913 0.0841,-0.0841 0.12614,-0.18454 0.12614,-0.30133 l 0,-1.2684 -0.84092,0 0,0.84093 -0.84093,0 0,-1.31045 1.68185,0 0,-1.21233 m -0.84092,0.46951 -0.84093,0 0,-1.31044 0.84093,0 0,1.31044"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path5423"
+                 style="font-size:7.0077157px;word-spacing:-0.74587125px;stroke:#0000ff"
+                 d="m -161.47972,594.91205 2.52278,0 0,1.68886 -0.84093,0 0,-0.84093 -0.84092,0 1.68185,3.36371 0,0.84793 -2.52278,0 0,-1.68886 0.84093,0 0,0.84093 0.84092,0 -1.68185,-3.36371 0,-0.84793"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path5425"
+                 style="font-size:7.0077157px;word-spacing:-0.74587125px;stroke:#0000ff"
+                 d="m -156.58176,595.76699 0.81289,0 0,-0.85494 -2.43868,0 0,0.85494 0.81289,0 0,4.20463 0.8129,0 0,-4.20463"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path5427"
+                 style="font-size:7.0077157px;word-spacing:-0.74587125px;stroke:#0000ff"
+                 d="m -153.35164,595.54274 0,3.05537 -0.84093,0 0,-3.05537 0.84093,0 m -1.68186,-0.64471 0,5.07359 0.84093,0 0,-0.53259 0.89699,0 0,0.53259 0.79888,0 0,-5.07359 -2.5368,0"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path5429"
+                 style="font-size:7.0077157px;word-spacing:-0.74587125px;stroke:#0000ff"
+                 d="m -150.10751,597.8623 0.42046,0 c 0.1168,0 0.2149,-0.0397 0.29433,-0.11913 0.0841,-0.0841 0.12613,-0.18454 0.12614,-0.30134 l 0,-2.10932 c -1e-5,-0.11679 -0.042,-0.2149 -0.12614,-0.29432 -0.0794,-0.0841 -0.17753,-0.12614 -0.29433,-0.12614 l -2.10231,0 0,5.05957 0.84092,0 0,-2.10932 0.84093,2.10932 0.84093,0 -0.84093,-2.10932 m 0,-0.84093 -0.84093,0 0,-1.26139 0.84093,0 0,1.26139"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path5431"
+                 style="font-size:7.0077157px;word-spacing:-0.74587125px;stroke:#0000ff"
+                 d="m -146.89141,595.76699 0.8129,0 0,-0.85494 -2.43869,0 0,0.85494 0.8129,0 0,4.20463 0.81289,0 0,-4.20463"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path5433"
+                 style="font-size:7.0077157px;word-spacing:-0.74587125px;stroke:#0000ff"
+                 d="m -144.47418,594.91205 -0.84093,0 0,5.05957 0.84093,0 0,-5.05957"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path5435"
+                 style="font-size:7.0077157px;word-spacing:-0.74587125px;stroke:#0000ff"
+                 d="m -143.34835,594.91205 1.68185,0 c 0.1168,0 0.2149,0.0421 0.29433,0.12614 0.0841,0.0794 0.12613,0.17753 0.12614,0.29432 l 0,4.63911 -0.84093,0 0,-4.21865 -0.82691,0 0,4.21865 -0.85494,0 0,-4.63911 c 0,-0.11679 0.0397,-0.2149 0.11913,-0.29432 0.0841,-0.0841 0.18453,-0.12614 0.30133,-0.12614"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path5437"
+                 style="font-size:7.0077157px;word-spacing:-0.74587125px;stroke:#0000ff"
+                 d="m -138.01592,595.33251 c 0,-0.11679 -0.0421,-0.2149 -0.12614,-0.29432 -0.0794,-0.0841 -0.17753,-0.12614 -0.29432,-0.12614 l -1.68185,0 c -0.1168,0 -0.21724,0.0421 -0.30133,0.12614 -0.0794,0.0794 -0.11913,0.17753 -0.11913,0.29432 l 0,2.10932 c 0,0.1168 0.0397,0.21724 0.11913,0.30134 0.0841,0.0794 0.18453,0.11913 0.30133,0.11913 l 1.26139,0 0,1.26139 -0.84093,0 0,-0.84093 -0.84092,0 0,1.68886 2.10231,0 c 0.11679,0 0.2149,-0.0397 0.29432,-0.11913 0.0841,-0.0841 0.12614,-0.18454 0.12614,-0.30133 l 0,-4.21865 m -1.68185,1.68886 0,-1.26139 0.84093,0 0,1.26139 -0.84093,0"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path5439"
+                 style="font-size:7.0077157px;word-spacing:-0.74587125px;stroke:#0000ff"
+                 d="m -133.24496,594.92606 -0.8129,0 -0.89698,2.57884 0.82691,2.46672 0.84092,0 -0.88297,-2.43869 0.92502,-2.60687 m -2.56483,-0.014 0,5.05957 0.84093,0 0,-5.05957 -0.84093,0"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path5441"
+                 style="font-size:7.0077157px;word-spacing:-0.74587125px;stroke:#0000ff"
+                 d="m -131.73841,594.91205 -0.84093,0 0,5.05957 0.84093,0 0,-5.05957"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+              <path
+                 id="path5443"
+                 style="font-size:7.0077157px;word-spacing:-0.74587125px;stroke:#0000ff"
+                 d="m -129.36521,595.76699 0.8129,0 0,-0.85494 -2.43869,0 0,0.85494 0.8129,0 0,4.20463 0.81289,0 0,-4.20463"
+                 ns5245954:connector-curvature="0"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <path
+           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 850.0925,696.97352 6.45235,0 -5.83363,9.81111 5.65685,-0.0884 -11.49048,14.53988 4.06586,-11.66726 -5.21491,0 z"
+           id="path5980"
+           ns5245954:connector-curvature="0"
+           inkscape:connector-curvature="0" />
+        <g
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:19.74025917px;line-height:85.00000238%;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="text5982"
+           transform="translate(0,1.5571175e-4)">
+          <path
+             ns5245954:connector-curvature="0"
+             d="m 841.02799,732.09791 2.175,0 0,-1.2875 1.3,0 0,1.7 -1.5625,0 0,1.4625 1.5625,0 0,1.7 -1.3,0 0,-1.3 -2.175,0 0,2.1125 q 0,0.1625 0.0875,0.3125 0.0875,0.15 0.2375,0.2625 0.15,0.1125 0.3375,0.175 0.2,0.0625 0.425,0.0625 l 3.4625,0 q 0.45,0 0.7625,-0.2375 0.3125,-0.25 0.3125,-0.575 l 0,-6.5 q 0,-0.325 -0.3125,-0.5625 -0.3125,-0.25 -0.7625,-0.25 l -3.4625,0 q -0.225,0 -0.425,0.0625 -0.1875,0.0625 -0.3375,0.175 -0.15,0.1125 -0.2375,0.2625 -0.0875,0.15 -0.0875,0.3125 l 0,2.1125 z"
+             style="font-size:12.5px;line-height:85.00000238%;text-align:center;text-anchor:middle;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="path15443"
+             inkscape:connector-curvature="0" />
+          <path
+             ns5245954:connector-curvature="0"
+             d="m 847.66862,729.17291 0,1.5 3.3375,5 -1.1625,0 0,-1.3 -2.175,0 0,2.925 5.625,0 0,-1.5 -3.325,-4.9875 1.175,0 0,1.2875 2.15,0 0,-2.925 -5.625,0 z"
+             style="font-size:12.5px;line-height:85.00000238%;text-align:center;text-anchor:middle;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="path15445"
+             inkscape:connector-curvature="0" />
+          <path
+             ns5245954:connector-curvature="0"
+             d="m 837.70768,741.43541 1.7375,0 0,4.8625 -1.7375,0 0,1.625 5.625,0 0,-1.625 -1.725,0 0,-6.5 -3.9,0 0,1.6375 z"
+             style="font-size:12.5px;line-height:85.00000238%;text-align:center;text-anchor:middle;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="path15447"
+             inkscape:connector-curvature="0" />
+          <path
+             ns5245954:connector-curvature="0"
+             d="m 847.8233,743.13541 0,-1.7125 -3.475,0 0,-0.8125 q 0,-0.1625 0.0875,-0.3125 0.0875,-0.15 0.2375,-0.2625 0.15,-0.1125 0.3375,-0.175 0.2,-0.0625 0.425,-0.0625 l 3.4625,0 q 0.45,0 0.7625,0.25 0.3125,0.2375 0.3125,0.5625 l 0,3.9875 -3.45,0 0,1.7 1.3,0 0,-1.3 2.15,0 0,2.1125 q 0,0.325 -0.3125,0.575 -0.3125,0.2375 -0.7625,0.2375 l -3.4625,0 q -0.225,0 -0.425,-0.0625 -0.1875,-0.0625 -0.3375,-0.175 -0.15,-0.1125 -0.2375,-0.2625 -0.0875,-0.15 -0.0875,-0.3125 l 0,-3.975 3.475,0 z"
+             style="font-size:12.5px;line-height:85.00000238%;text-align:center;text-anchor:middle;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="path15449"
+             inkscape:connector-curvature="0" />
+          <path
+             ns5245954:connector-curvature="0"
+             d="m 850.95143,739.79791 2.1875,0 0.6625,4.05 0.6875,-4.05 2.175,0 -1.8,8.125 -2.1,0 -1.8125,-8.125 z"
+             style="font-size:12.5px;line-height:85.00000238%;text-align:center;text-anchor:middle;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="path15451"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="translate(-12.000001,0)"
+           id="g6852" />
+        <g
+           transform="translate(-2.0000002,2.0000002)"
+           id="g6885">
+          <g
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:Soviet;-inkscape-font-specification:Soviet;letter-spacing:0px;word-spacing:0px;fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.70866144;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="text5241">
+            <path
+               inkscape:connector-curvature="0"
+               d="m 843.33177,749.37793 0,5.995 -1.65,0 0,-7.26 -1.65,0 0,8.91 3.41,0 0,1.045 1.5675,0 0,-9.955 -1.6775,0 0,1.265 z"
+               style="font-size:13.75px;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none"
+               id="path6805" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 850.35716,748.14043 -2.97,0 q -0.4125,0 -0.70125,0.28875 -0.28875,0.28875 -0.28875,0.70125 l 0,7.96125 q 0,0.4125 0.23375,0.6875 0.23375,0.26125 0.75625,0.28875 l 3.135,0 q 0.3575,-0.055 0.59125,-0.33 0.23375,-0.28875 0.23375,-0.64625 l 0,-7.96125 q 0,-0.4125 -0.28875,-0.70125 -0.28875,-0.28875 -0.70125,-0.28875 z m -2.31,8.29125 0,-6.6275 1.65,0 0,6.6275 -1.65,0 z"
+               style="font-size:13.75px;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none"
+               id="path6807" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 856.00755,749.37793 0,5.995 -1.65,0 0,-5.995 1.65,0 z m -3.3,-1.265 0,9.955 1.65,0 0,-1.045 1.76,0 0,1.045 1.5675,0 0,-9.955 -4.9775,0 z"
+               style="font-size:13.75px;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none"
+               id="path6809" />
+          </g>
+        </g>
+        <g
+           id="text5010"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:28.18771553px;line-height:125%;font-family:Soviet;-inkscape-font-specification:Soviet;letter-spacing:0px;word-spacing:0px;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.0003932,0.99960695)">
+          <path
+             id="path5071"
+             d="m 678.29962,361.64621 6.76506,0 c 0.46978,2e-5 0.86441,0.16915 1.18388,0.50738 0.33824,0.31948 0.50737,0.71411 0.50738,1.18388 l 0,18.66027 -3.38253,0 0,-16.969 -3.32615,0 0,16.969 -3.4389,0 0,-18.66027 c 0,-0.46977 0.15973,-0.8644 0.47919,-1.18388 0.33825,-0.33823 0.74228,-0.50736 1.21207,-0.50738"
+             ns5245954:connector-curvature="0"
+             inkscape:connector-curvature="0"
+             style="stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none" />
+          <path
+             id="path5073"
+             d="m 696.30981,364.18311 0,12.28984 -3.38252,0 0,-12.28984 3.38252,0 m -6.76505,-2.59327 0,20.4079 3.38253,0 0,-2.14226 3.60802,0 0,2.14226 3.2134,0 0,-20.4079 -10.20395,0"
+             ns5245954:connector-curvature="0"
+             inkscape:connector-curvature="0"
+             style="stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none" />
+          <path
+             id="path5075"
+             d="m 712.74149,361.64621 -10.14758,0 0,6.79324 3.38253,0 0,-3.38253 3.38252,0 -6.76505,13.53011 0,3.41071 10.14758,0 0,-6.79324 -3.38253,0 0,3.38253 -3.38252,0 6.76505,-13.53011 0,-3.41071"
+             ns5245954:connector-curvature="0"
+             inkscape:connector-curvature="0"
+             style="stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none" />
+          <path
+             id="path5077"
+             d="m 725.73426,368.43945 0,-5.10198 c -10e-6,-0.46977 -0.16913,-0.8644 -0.50738,-1.18388 -0.31947,-0.33823 -0.7141,-0.50736 -1.18388,-0.50738 l -6.76505,0 c -0.4698,2e-5 -0.87382,0.16915 -1.21207,0.50738 -0.31947,0.31948 -0.4792,0.71411 -0.47919,1.18388 l 0,16.96901 c -10e-6,0.4698 0.15972,0.87382 0.47919,1.21207 0.33825,0.31946 0.74227,0.47919 1.21207,0.47919 l 6.76505,0 c 0.46978,0 0.86441,-0.15973 1.18388,-0.47919 0.33825,-0.33825 0.50737,-0.74227 0.50738,-1.21207 l 0,-5.10198 -3.38252,0 0,3.38253 -3.38253,0 0,-5.2711 6.76505,0 0,-4.87648 m -3.38252,1.88858 -3.38253,0 0,-5.27111 3.38253,0 0,5.27111"
+             ns5245954:connector-curvature="0"
+             inkscape:connector-curvature="0"
+             style="stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none" />
+          <path
+             id="path5079"
+             d="m 739.9673,384.59101 0,-1.86039 -12.71266,0 0,1.86039 12.71266,0"
+             ns5245954:connector-curvature="0"
+             inkscape:connector-curvature="0"
+             style="stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none" />
+          <path
+             id="path5081"
+             d="m 741.40707,368.43945 0,-5.10198 c 0,-0.46977 0.15973,-0.8644 0.4792,-1.18388 0.33825,-0.33823 0.74227,-0.50736 1.21207,-0.50738 l 6.76505,0 c 0.46978,2e-5 0.86441,0.16915 1.18388,0.50738 0.33824,0.31948 0.50737,0.71411 0.50738,1.18388 l 0,16.96901 c -1e-5,0.4698 -0.16914,0.87382 -0.50738,1.21207 -0.31947,0.31946 -0.7141,0.47919 -1.18388,0.47919 l -6.76505,0 c -0.4698,0 -0.87382,-0.15973 -1.21207,-0.47919 -0.31947,-0.33825 -0.4792,-0.74227 -0.4792,-1.21207 l 0,-5.10198 3.38253,0 0,3.38253 3.38253,0 0,-5.2711 -3.04428,0 0,-2.9879 3.04428,0 0,-5.27111 -3.38253,0 0,3.38253 -3.38253,0"
+             ns5245954:connector-curvature="0"
+             inkscape:connector-curvature="0"
+             style="stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none" />
+          <path
+             id="path5083"
+             d="m 761.1649,370.32803 -6.76505,0 0,9.97845 c 0,0.4698 0.15973,0.87382 0.47919,1.21207 0.33825,0.31946 0.74227,0.47919 1.21207,0.47919 l 6.76505,0 c 0.46979,0 0.86442,-0.15973 1.18389,-0.47919 0.33824,-0.33825 0.50737,-0.74227 0.50738,-1.21207 l 0,-5.10198 -3.38253,0 0,3.38253 -3.38253,0 0,-5.2711 6.76506,0 0,-9.97846 c -10e-6,-0.46977 -0.16914,-0.8644 -0.50738,-1.18388 -0.31947,-0.33823 -0.7141,-0.50736 -1.18389,-0.50738 l -6.76505,0 c -0.4698,2e-5 -0.87382,0.16915 -1.21207,0.50738 -0.31946,0.31948 -0.47919,0.71411 -0.47919,1.18388 l 0,1.69127 6.76505,0 0,5.29929"
+             ns5245954:connector-curvature="0"
+             inkscape:connector-curvature="0"
+             style="stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none" />
+        </g>
+        <g
+           id="text4158"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20.00000191px;line-height:125%;font-family:Soviet;-inkscape-font-specification:Soviet;letter-spacing:0px;word-spacing:0px;fill:none;stroke:#0000ff;stroke-width:1;stroke-opacity:1">
+          <path
+             id="path5101"
+             style="font-size:24.00000381px;stroke:#0000ff"
+             d="m 933.4204,950.40418 0,-2.904 5.76,0 0,14.42401 2.88,0 0,2.904 -8.64,0 0,-2.904 2.88,0 0,-11.52001 -2.88,0"
+             ns5245954:connector-curvature="0"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="text5013"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20.00000191px;line-height:125%;font-family:Soviet;-inkscape-font-specification:Soviet;letter-spacing:0px;word-spacing:0px;fill:none;stroke:#0000ff;stroke-width:1;stroke-opacity:1">
+          <path
+             id="path5068"
+             style="font-size:24.00000381px;stroke:#0000ff"
+             d="m 963.96464,499.89405 -5.76,0 0,8.496 c 0,0.4 0.136,0.744 0.408,1.032 0.288,0.272 0.632,0.408 1.032,0.408 l 5.76,0 c 0.39999,0 0.73599,-0.136 1.008,-0.408 0.28799,-0.288 0.43199,-0.632 0.432,-1.032 l 0,-4.344 -2.88,0 0,2.88 -2.88,0 0,-4.488 5.76,0 0,-8.496 c -10e-6,-0.39999 -0.14401,-0.73599 -0.432,-1.00801 -0.27201,-0.28798 -0.60801,-0.43198 -1.008,-0.432 l -5.76,0 c -0.4,2e-5 -0.744,0.14402 -1.032,0.432 -0.272,0.27202 -0.408,0.60802 -0.408,1.00801 l 0,1.44 5.76,0 0,4.512"
+             ns5245954:connector-curvature="0"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="text5017"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20.00000191px;line-height:125%;font-family:Soviet;-inkscape-font-specification:Soviet;letter-spacing:0px;word-spacing:0px;fill:none;stroke:#0000ff;stroke-width:1;stroke-opacity:1">
+          <path
+             id="path5104"
+             style="font-size:24.00000381px;stroke:#0000ff"
+             d="m 492.20461,953.28608 0,-4.344 c 0,-0.39999 0.136,-0.73599 0.408,-1.008 0.288,-0.28799 0.632,-0.43199 1.032,-0.432 l 5.76,0 c 0.39999,10e-6 0.73599,0.14401 1.008,0.432 0.28799,0.27201 0.43199,0.60801 0.432,1.008 l 0,14.448 c -10e-6,0.4 -0.14401,0.744 -0.432,1.032 -0.27201,0.272 -0.60801,0.408 -1.008,0.408 l -5.76,0 c -0.4,0 -0.744,-0.136 -1.032,-0.408 -0.272,-0.288 -0.408,-0.632 -0.408,-1.032 l 0,-4.344 2.88,0 0,2.88 2.88,0 0,-4.488 -2.592,0 0,-2.544 2.592,0 0,-4.488 -2.88,0 0,2.88 -2.88,0"
+             ns5245954:connector-curvature="0"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="text5021"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20.00000191px;line-height:125%;font-family:Soviet;-inkscape-font-specification:Soviet;letter-spacing:0px;word-spacing:0px;fill:none;stroke:#0000ff;stroke-width:1;stroke-opacity:1">
+          <path
+             id="path5092"
+             style="font-size:24.00000381px;stroke:#0000ff"
+             d="m 477.58818,493.73309 0,10.464 -2.88,0 0,-12.672 -2.88,0 0,15.552 5.952,0 0,1.824 2.736,0 0,-17.376 -2.928,0 0,2.208"
+             ns5245954:connector-curvature="0"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="text5025"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20.00000191px;line-height:125%;font-family:Soviet;-inkscape-font-specification:Soviet;letter-spacing:0px;word-spacing:0px;fill:none;stroke:#0000ff;stroke-width:1;stroke-opacity:1"
+           transform="matrix(0,1,-1,0,0,0)">
+          <path
+             id="path5062"
+             style="font-size:24.00000381px;stroke:#0000ff"
+             d="m 83.638399,-902.32864 -5.760001,0 0,8.496 c -10e-7,0.4 0.135999,0.744 0.408,1.032 0.287999,0.272 0.631998,0.408 1.032001,0.408 l 5.76,0 c 0.399992,0 0.735991,-0.136 1.008001,-0.408 0.28799,-0.288 0.43199,-0.632 0.432,-1.032 l 0,-4.344 -2.880001,0 0,2.88 -2.88,0 0,-4.488 5.760001,0 0,-8.496 c -1e-5,-0.39999 -0.14401,-0.73599 -0.432,-1.008 -0.27201,-0.28798 -0.608009,-0.43198 -1.008001,-0.432 l -5.76,0 c -0.400003,2e-5 -0.744002,0.14402 -1.032001,0.432 -0.272001,0.27201 -0.408001,0.60801 -0.408,1.008 l 0,1.44 5.760001,0 0,4.512"
+             ns5245954:connector-curvature="0"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="text5029"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20.00000191px;line-height:125%;font-family:Soviet;-inkscape-font-specification:Soviet;letter-spacing:0px;word-spacing:0px;fill:none;stroke:#0000ff;stroke-width:1;stroke-opacity:1"
+           transform="matrix(0,-1,1,0,0,0)">
+          <path
+             id="path5065"
+             style="font-size:24.00000381px;stroke:#0000ff"
+             d="m -194.65283,533.91763 0,10.464 -2.88,0 0,-12.672 -2.88,0 0,15.552 5.952,0 0,1.824 2.736,0 0,-17.376 -2.928,0 0,2.208"
+             ns5245954:connector-curvature="0"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="text5033"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20.00000191px;line-height:125%;font-family:Soviet;-inkscape-font-specification:Soviet;letter-spacing:0px;word-spacing:0px;fill:none;stroke:#0000ff;stroke-width:1;stroke-opacity:1"
+           transform="scale(-1,-1)">
+          <path
+             id="path5095"
+             style="font-size:24.00000381px;stroke:#0000ff"
+             d="m -1010.8611,-766.31097 0,-4.344 c 0,-0.39998 0.136,-0.73598 0.408,-1.008 0.288,-0.28798 0.632,-0.43198 1.032,-0.432 l 5.76,0 c 0.4,2e-5 0.736,0.14402 1.008,0.432 0.288,0.27202 0.432,0.60802 0.432,1.008 l 0,14.448 c 0,0.4 -0.144,0.744 -0.432,1.032 -0.272,0.272 -0.608,0.408 -1.008,0.408 l -5.76,0 c -0.4,0 -0.744,-0.136 -1.032,-0.408 -0.272,-0.288 -0.408,-0.632 -0.408,-1.032 l 0,-4.344 2.88,0 0,2.88 2.88,0 0,-4.488 -2.592,0 0,-2.544 2.592,0 0,-4.488 -2.88,0 0,2.88 -2.88,0"
+             ns5245954:connector-curvature="0"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="text5037"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20.00000191px;line-height:125%;font-family:Soviet;-inkscape-font-specification:Soviet;letter-spacing:0px;word-spacing:0px;fill:none;stroke:#0000ff;stroke-width:1;stroke-opacity:1"
+           transform="scale(-1,-1)">
+          <path
+             id="path5098"
+             style="font-size:24.00000381px;stroke:#0000ff"
+             d="m -437.06038,-770.92419 0,-2.904 5.76001,0 0,14.42401 2.88,0 0,2.904 -8.64001,0 0,-2.904 2.88,0 0,-11.52001 -2.88,0"
+             ns5245954:connector-curvature="0"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g6972"
+           style="fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+          <g
+             transform="matrix(0,1.25,-1.25,0,-2.3277002,2.2880699)"
+             id="g7893"
+             style="display:inline;fill:none;stroke:#0000ff;stroke-width:0.05669291;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               id="path7895"
+               style="fill:none;stroke:#0000ff;stroke-width:0.05669291;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 103.703,-242.148 0,-5.075 c 0,-0.461 -0.168,-0.855 -0.5,-1.179 -0.32,-0.332 -0.719,-0.496 -1.183,-0.496 l -6.731,0 c -0.461,0 -0.855,0.164 -1.187,0.496 -0.332,0.324 -0.5,0.718 -0.5,1.179 l 0,16.871 c 0,0.465 0.168,0.872 0.5,1.204 0.332,0.316 0.726,0.476 1.187,0.476 l 6.731,0 c 0.464,0 0.863,-0.16 1.183,-0.476 0.332,-0.332 0.5,-0.739 0.5,-1.204 l 0,-5.074 -3.367,0 0,3.371 -3.363,0 0,-5.234 6.73,0 0,-4.859 z m -3.367,1.886 -3.363,0 0,-5.254 3.363,0 0,5.254 z m 6.18,-8.636 10.097,0 0,6.75 -3.363,0 0,-3.368 -3.363,0 6.726,13.461 0,3.383 -10.097,0 0,-6.754 3.371,0 0,3.371 3.363,0 -6.734,-13.461 0,-3.382 z m 23.011,6.75 0,-5.075 c 0,-0.461 -0.164,-0.855 -0.496,-1.179 -0.324,-0.332 -0.719,-0.496 -1.191,-0.496 l -6.723,0 c -0.457,0 -0.851,0.164 -1.183,0.496 -0.332,0.324 -0.5,0.718 -0.5,1.179 l 0,16.871 c 0,0.465 0.168,0.872 0.5,1.204 0.332,0.316 0.726,0.476 1.183,0.476 l 6.723,0 c 0.472,0 0.867,-0.16 1.191,-0.476 0.332,-0.332 0.496,-0.739 0.496,-1.204 l 0,-5.074 -3.363,0 0,3.371 -3.371,0 0,-13.461 3.371,0 0,3.368 3.363,0 z" />
+            <rect
+               style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:0.05669291;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+               id="rect7010"
+               width="850.08826"
+               height="850.08826"
+               x="2.5876298"
+               y="-1.6909292"
+               transform="matrix(0,-1,1,0,0,0)" />
+            <path
+               style="fill:none;fill-rule:evenodd;stroke:#ff0000;stroke-width:0.05669291;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 15.358578,-301.20536 817.047162,0.19217"
+               id="path7012"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cc" />
+          </g>
+          <g
+             id="g13465"
+             transform="matrix(0,-0.97804301,0.97804301,0,236.64363,-38.563179)"
+             style="display:inline;fill:none;stroke:#0000ff;stroke-width:0.07245708;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               d="m -155.578,45.477 0,31.23 c 0,1.594 -1.289,2.879 -2.879,2.879 l -50.887,0 c -1.59,0 -2.875,-1.285 -2.875,-2.879 l 0,-31.23 c 0,-1.594 1.285,-2.875 2.875,-2.875 l 50.887,0 c 1.59,0 2.879,1.281 2.879,2.875 z"
+               style="fill:none;stroke:#0000ff;stroke-width:0.07245708;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="path13467" />
+          </g>
+          <g
+             transform="matrix(0,1,-1,0,27.750003,19.250158)"
+             style="font-style:normal;font-weight:normal;font-size:27.48832321px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="text5138">
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               d="m 69.116144,-303.3691 -0.944911,2.85192 -0.944911,-2.85192 -2.920634,0 0,11.16713 2.989355,0 0,-5.01661 0.87619,0.65284 0.910551,-0.65284 0,5.01661 2.954995,0 0,-11.16713 -2.920635,0 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:17.18020248px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="path15383" />
+          </g>
+          <g
+             id="g5679"
+             transform="matrix(0,1,-1,0,399.77701,-210.39949)"
+             style="display:inline;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+            <path
+               inkscape:connector-curvature="0"
+               id="path5134"
+               d="m 307.3787,74.383632 a 9.8529453,9.8529453 0 0 1 -9.85294,9.852946 9.8529453,9.8529453 0 0 1 -9.85295,-9.852946 9.8529453,9.8529453 0 0 1 9.85295,-9.852945 9.8529453,9.8529453 0 0 1 9.85294,9.852945 z"
+               style="opacity:0.75800003;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+               ns5245954:connector-curvature="0" />
+            <path
+               inkscape:connector-curvature="0"
+               id="circle5144"
+               d="m 299.2222,84.243999 a 1.4779419,1.4779419 0 0 1 -1.47794,1.477942 1.4779419,1.4779419 0 0 1 -1.47794,-1.477942 1.4779419,1.4779419 0 0 1 1.47794,-1.477942 1.4779419,1.4779419 0 0 1 1.47794,1.477942 z"
+               style="opacity:0.75800003;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+               ns5245954:connector-curvature="0" />
+            <path
+               inkscape:connector-curvature="0"
+               id="circle5146"
+               d="m 306.26005,80.865856 a 1.4779419,1.4779419 0 0 1 -1.47795,1.477942 1.4779419,1.4779419 0 0 1 -1.47794,-1.477942 1.4779419,1.4779419 0 0 1 1.47794,-1.477942 1.4779419,1.4779419 0 0 1 1.47795,1.477942 z"
+               style="opacity:0.75800003;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+               ns5245954:connector-curvature="0" />
+            <path
+               inkscape:connector-curvature="0"
+               id="circle5148"
+               d="m 292.04368,81.319629 a 1.4779419,1.4779419 0 0 1 -1.47795,1.477942 1.4779419,1.4779419 0 0 1 -1.47794,-1.477942 1.4779419,1.4779419 0 0 1 1.47794,-1.477942 1.4779419,1.4779419 0 0 1 1.47795,1.477942 z"
+               style="opacity:0.75800003;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+               ns5245954:connector-curvature="0" />
+          </g>
+          <path
+             inkscape:connector-curvature="0"
+             id="path5152"
+             d="m 317.64644,85.306619 4e-5,2.2e-5 c -0.28959,4.73e-4 -3.25191,0.03052 -6.23046,0.07031 -1.48928,0.0199 -2.97637,0.04305 -4.125,0.06445 -0.72532,0.0048 -1.42165,0.03458 -2.12305,0.0625 -4.39137,0.60169 -7.73948,3.73508 -7.72656,8.53711 0.0261,9.704259 -0.12891,17.212899 -0.12891,17.212899"
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             transform="translate(-2.0000002,2.0000002)"
+             sodipodi:nodetypes="ccsccsc" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path5403"
+             d="m 292.56445,167.16802 c 0,0 0.0599,23.01032 0,27.81836 -0.0101,0.80833 -0.46807,1.35935 -1.30664,1.89062 -0.83857,0.53127 -2.02068,0.96454 -3.2207,1.39844 -1.20002,0.4339 -2.41786,0.86814 -3.37109,1.49609 -0.95324,0.62796 -1.3288,1.57553 -1.25717,2.78113 0.11901,2.00318 0.0603,6.29571 0.0603,6.29571"
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             transform="translate(-2.0000002,2.0000002)"
+             sodipodi:nodetypes="ccssssc" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path5405"
+             d="m 294.88486,169.18364 0.0742,41.85501 z"
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             sodipodi:nodetypes="ccc" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path5407"
+             d="m 301.19728,167.0273 -10e-6,4e-5 c 0,0 -0.0277,20.55935 -0.0371,28.08985 -0.002,1.1806 0.74508,2.05012 1.70117,2.64258 0.95609,0.59245 2.15685,0.99259 3.33008,1.39257 1.17322,0.39999 2.31888,0.79892 3.12109,1.29688 0.80221,0.49796 1.7984,1.09708 1.79499,1.87906 -0.007,2.39517 -0.049,4.28409 -0.042,6.67926"
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             transform="translate(-2.0000002,2.0000002)"
+             sodipodi:nodetypes="cccssscc" />
+          <g
+             transform="matrix(0,1,-1,0,26.000001,10.250157)"
+             style="font-style:normal;font-weight:normal;font-size:13.37965488px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="text5409">
+            <path
+               sodipodi:nodetypes="cccccccccccccccccccccc"
+               inkscape:connector-curvature="0"
+               id="path15310"
+               d="m 207.30471,-287.91603 c -0.25569,0.0226 -0.69569,0.15786 -0.8516,0.4688 -0.13099,0.28444 -0.053,0.60927 -0.0742,0.9138 0.003,0.96737 -0.006,1.9351 0.004,2.90224 0.10863,0.51189 0.69551,0.70384 1.16097,0.66839 l 2.5538,0 0,2.00391 -1.65625,0 0,-1.39063 -2.0625,0 0,2.86523 c 1.61488,-0.002 3.22995,0.005 4.84472,-0.003 0.44901,-0.008 0.97005,-0.34341 0.91114,-0.84434 -0.003,-2.30552 0.005,-4.61134 -0.004,-6.91668 -0.10219,-0.47995 -0.65613,-0.69902 -1.10484,-0.66727 l -3.72162,0 z m 1.0664,1.41795 0,2.1309 1.79688,0 0,-2.13086 c -0.59895,-3e-5 -1.198,5e-5 -1.79688,-4e-5 z"
+               style="color:#000000;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:medium;line-height:125%;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+            <path
+               sodipodi:nodetypes="ccccccsccccccscscc"
+               inkscape:connector-curvature="0"
+               id="path15312"
+               d="m 214.51758,-288.21484 c -0.17604,0 -0.34415,0.0243 -0.50391,0.0742 l -0.002,0 -0.002,0 c -0.14966,0.0499 -0.2863,0.12147 -0.40821,0.21289 -0.12309,0.0923 -0.2246,0.20283 -0.29883,0.33007 -0.0757,0.12975 -0.11523,0.27198 -0.11523,0.41797 l 0,7.9961 2.67578,0 0,-6.95899 1.04297,0 0,6.95899 2.63477,0 0,-7.9961 c 0,-0.28552 -0.14814,-0.54266 -0.4004,-0.73437 -0.25298,-0.20105 -0.5655,-0.30078 -0.91601,-0.30078 l -3.70703,0 z"
+               style="color:#000000;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:medium;line-height:125%;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+            <path
+               sodipodi:nodetypes="ccccccccccccccccccccc"
+               inkscape:connector-curvature="0"
+               id="path15314"
+               d="m 220.29492,-288.21484 0,9.03125 4.5625,0 0.0215,-0.006 c 0.59255,-0.15263 0.95133,-0.26851 1.15429,-0.43164 0.21025,-0.14981 0.37626,-0.43365 0.57618,-0.87891 l 0.0137,-0.0332 0,-6.32227 -0.008,-0.0254 c -0.12033,-0.38878 -0.28087,-0.68372 -0.49804,-0.88281 -0.21489,-0.22411 -0.58755,-0.34914 -1.14258,-0.44922 l -0.0156,-0.002 -0.0156,0 -4.64844,0 z m 2.32813,1.75195 0,5.53906 0.16601,0 1.56055,0 0,-5.53906 z"
+               style="color:#000000;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:medium;line-height:125%;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+          </g>
+          <g
+             transform="matrix(0,1,-1,0,-2.0000002,10.250157)"
+             style="font-style:normal;font-weight:normal;font-size:13.37965488px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="text5413">
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               d="m 210.38029,-296.42851 0,1.77949 -2.26116,0 0,-1.77949 -1.76612,0 0,-1.47176 1.83302,0 0,-2.02033 2.19426,0 0,2.02033 1.79287,0 0,1.47176 -1.79287,0 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="path15303" />
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               d="m 219.34863,-300.44241 0,-0.86967 q 0,-0.34787 -0.33449,-0.60209 -0.33449,-0.26759 -0.81616,-0.26759 l -3.70616,0 q -0.24084,0 -0.45491,0.0669 -0.2007,0.0669 -0.36125,0.18731 -0.16056,0.12042 -0.25422,0.28098 -0.0936,0.16055 -0.0936,0.33449 l 0,4.26811 3.71954,0 0,1.81963 -1.39148,0 0,-1.39148 -2.32806,0 0,2.26116 q 0,0.17393 0.0936,0.33449 0.0937,0.16055 0.25422,0.28097 0.16055,0.12042 0.36125,0.18732 0.21407,0.0669 0.45491,0.0669 l 3.70616,0 q 0.48167,0 0.81616,-0.25421 0.33449,-0.26759 0.33449,-0.61546 l 0,-4.25473 -3.69278,0 0,-1.83302 3.69278,0 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="path15305" />
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               d="m 220.39559,-302.18176 2.34144,0 0.70912,4.33501 0.73588,-4.33501 2.32806,0 -1.92667,8.69677 -2.24778,0 -1.94005,-8.69677 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="path15307" />
+          </g>
+          <path
+             inkscape:connector-curvature="0"
+             id="path5691"
+             d="m 320.52137,91.916033 c -0.20715,-0.08285 -0.49804,-0.203293 -0.85351,-0.34961 -0.71095,-0.292633 -1.68668,-0.686682 -2.83203,-1.082031 -2.29071,-0.790698 -5.25665,-1.596325 -8.16797,-1.634766 l 1.1e-4,-1.7e-5 c -1.58071,-0.02088 -3.32618,0.585067 -4.30274,1.304688 -1.74173,1.283481 -2.84636,3.425015 -2.83984,6.167969 0.02,8.428034 -0.0977,14.949214 -0.0977,14.949214"
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             transform="translate(-2.0000002,2.0000002)"
+             sodipodi:nodetypes="cssccssc" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path5693"
+             d="m 293.58202,111.25197 c 0,0 0.19728,-8.63188 0.16406,-19.787111 -0.008,-2.738171 1.0803,-4.914054 2.89063,-6.47461 1.81033,-1.560555 4.35835,-2.496678 7.25781,-2.660156 0.0306,-0.0017 0.76421,-0.01759 1.66797,-0.0332 0.90376,-0.01561 2.02905,-0.03378 3.00586,-0.04883 0.24243,-0.0037 0.52011,-0.07518 0.93359,-0.185547 0.41349,-0.110363 0.93166,-0.264757 1.51953,-0.449219 1.17576,-0.368923 2.62859,-0.857944 4.04883,-1.345703 1.42025,-0.487759 2.80728,-0.97495 3.84571,-1.339844 0.51921,-0.182446 0.95087,-0.333476 1.25586,-0.439453"
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             transform="translate(-2.0000002,2.0000002)"
+             sodipodi:nodetypes="ccscsccsssc" />
+          <g
+             id="text5695"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:26.97394562px;line-height:125%;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';letter-spacing:0px;word-spacing:0px;display:inline;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="matrix(0,1,-1,0,-2.0000002,2.0000002)">
+            <path
+               inkscape:connector-curvature="0"
+               id="path5188"
+               style="fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 88.274355,-284.96079 -2.508577,0 q -0.377636,0.89014 -1.213828,0.89014 -0.296713,0 -0.836192,-0.1079 -0.512505,-0.1079 -1.29475,-0.29671 -0.89014,-0.26974 -1.510541,-0.37764 -0.593426,-0.10789 -0.89014,-0.10789 -1.132905,0 -1.996072,0.29671 -0.863166,0.26974 -1.483567,0.89014 l 0.05395,-0.027 q -0.269739,0.21579 -0.431583,0.45855 -0.161844,0.24277 -0.296713,0.53948 l 0,-0.027 q -0.107896,0.16184 -0.242766,0.5125 -0.107896,0.32369 -0.323687,0.86317 l 3.236873,0 q 0.242766,-0.89014 1.078958,-0.94409 3.668457,0.89014 4.99018,0.89014 3.425691,0 4.153988,-3.12898 l -0.485531,-0.32368 z" />
+          </g>
+          <path
+             inkscape:connector-curvature="0"
+             id="path6108"
+             d="m 283.48438,206.83008 c -1.08645,-1e-5 -1.97654,0.89011 -1.97657,1.97656 -4e-5,1.0865 0.89007,1.97852 1.97657,1.97852 1.08649,-1e-5 1.97855,-0.89203 1.97851,-1.97852 -3e-5,-1.08644 -0.89207,-1.97656 -1.97851,-1.97656 z"
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.75800003;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             transform="translate(-2.0000002,2.0000002)"
+             sodipodi:nodetypes="sssss" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path6361"
+             d="m 311.10938,206.95508 c -1.08645,-1e-5 -1.97654,0.89011 -1.97657,1.97656 -4e-5,1.0865 0.89007,1.97852 1.97657,1.97852 1.08649,-1e-5 1.97855,-0.89203 1.97851,-1.97852 -3e-5,-1.08644 -0.89207,-1.97656 -1.97851,-1.97656 z"
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.75800003;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             transform="translate(-2.0000002,2.0000002)"
+             sodipodi:nodetypes="sssss" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path6429"
+             d="m 296.98438,207.08008 c -1.08645,-1e-5 -1.97654,0.89011 -1.97657,1.97656 -4e-5,1.0865 0.89007,1.97852 1.97657,1.97852 1.08649,-1e-5 1.97855,-0.89203 1.97851,-1.97852 -3e-5,-1.08644 -0.89207,-1.97656 -1.97851,-1.97656 z"
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.75800003;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             transform="translate(-2.0000002,2.0000002)"
+             sodipodi:nodetypes="sssss" />
+          <g
+             transform="matrix(0,1,-1,0,0,0)"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.65526009px;line-height:125%;font-family:Soviet;-inkscape-font-specification:Soviet;letter-spacing:0px;word-spacing:0px;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="text5041">
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               d="m 227.44807,-286.54309 0,8.19084 -2.25436,0 0,-9.91918 -2.25435,0 0,12.17353 4.659,0 0,1.42776 2.14164,0 0,-13.60129 -2.29193,0 0,1.72834"
+               style="font-size:18.78631401px;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="path5086" />
+          </g>
+        </g>
+        <g
+           id="g6908"
+           style="stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none">
+          <g
+             style="stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="g7330"
+             transform="matrix(-1,0,0,-1,-7.8341211,1248.3176)">
+            <g
+               style="stroke:#0000ff;stroke-width:0.05669291;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="matrix(0,1.25,-1.25,0,-386.19926,878.54243)"
+               id="g7332">
+              <path
+                 inkscape:connector-curvature="0"
+                 ns5245954:connector-curvature="0"
+                 id="path7334"
+                 style="fill:none;stroke:#0000ff;stroke-width:0.05669291;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 d="m 103.703,-242.148 0,-5.075 c 0,-0.461 -0.168,-0.855 -0.5,-1.179 -0.32,-0.332 -0.719,-0.496 -1.183,-0.496 l -6.731,0 c -0.461,0 -0.855,0.164 -1.187,0.496 -0.332,0.324 -0.5,0.718 -0.5,1.179 l 0,16.871 c 0,0.465 0.168,0.872 0.5,1.204 0.332,0.316 0.726,0.476 1.187,0.476 l 6.731,0 c 0.464,0 0.863,-0.16 1.183,-0.476 0.332,-0.332 0.5,-0.739 0.5,-1.204 l 0,-5.074 -3.367,0 0,3.371 -3.363,0 0,-5.234 6.73,0 0,-4.859 z m -3.367,1.886 -3.363,0 0,-5.254 3.363,0 0,5.254 z m 6.18,-8.636 10.097,0 0,6.75 -3.363,0 0,-3.368 -3.363,0 6.726,13.461 0,3.383 -10.097,0 0,-6.754 3.371,0 0,3.371 3.363,0 -6.734,-13.461 0,-3.382 z m 23.011,6.75 0,-5.075 c 0,-0.461 -0.164,-0.855 -0.496,-1.179 -0.324,-0.332 -0.719,-0.496 -1.191,-0.496 l -6.723,0 c -0.457,0 -0.851,0.164 -1.183,0.496 -0.332,0.324 -0.5,0.718 -0.5,1.179 l 0,16.871 c 0,0.465 0.168,0.872 0.5,1.204 0.332,0.316 0.726,0.476 1.183,0.476 l 6.723,0 c 0.472,0 0.867,-0.16 1.191,-0.476 0.332,-0.332 0.496,-0.739 0.496,-1.204 l 0,-5.074 -3.363,0 0,3.371 -3.371,0 0,-13.461 3.371,0 0,3.368 3.363,0 z" />
+            </g>
+            <g
+               style="stroke:#0000ff;stroke-width:0.07245708;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="g7336"
+               transform="matrix(0,0.97804301,0.97804301,0,-147.99981,1198.8051)">
+              <path
+                 inkscape:connector-curvature="0"
+                 ns5245954:connector-curvature="0"
+                 d="m -155.578,45.477 0,31.23 c 0,1.594 -1.289,2.879 -2.879,2.879 l -50.887,0 c -1.59,0 -2.875,-1.285 -2.875,-2.879 l 0,-31.23 c 0,-1.594 1.285,-2.875 2.875,-2.875 l 50.887,0 c 1.59,0 2.879,1.281 2.879,2.875 z"
+                 style="fill:none;stroke:#0000ff;stroke-width:0.07245708;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path7338" />
+            </g>
+            <g
+               transform="matrix(0,-1,-1,0,-356.89343,1140.9917)"
+               style="font-style:normal;font-weight:normal;font-size:27.48832321px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="g7340">
+              <path
+                 inkscape:connector-curvature="0"
+                 ns5245954:connector-curvature="0"
+                 d="m 69.116144,-303.3691 -0.944911,2.85192 -0.944911,-2.85192 -2.920634,0 0,11.16713 2.989355,0 0,-5.01661 0.87619,0.65284 0.910551,-0.65284 0,5.01661 2.954995,0 0,-11.16713 -2.920635,0 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:17.18020248px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path7342" />
+            </g>
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               style="opacity:0.75800003;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+               d="m -59.250057,1063.2627 a 9.8529453,9.8529453 0 0 0 -9.852946,9.8529 9.8529453,9.8529453 0 0 0 9.852946,9.853 9.8529453,9.8529453 0 0 0 9.852945,-9.853 9.8529453,9.8529453 0 0 0 -9.852945,-9.8529 z"
+               id="path7346" />
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               style="opacity:0.75800003;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+               d="m -69.110424,1071.4192 a 1.4779419,1.4779419 0 0 0 -1.477942,1.4779 1.4779419,1.4779419 0 0 0 1.477942,1.478 1.4779419,1.4779419 0 0 0 1.477942,-1.478 1.4779419,1.4779419 0 0 0 -1.477942,-1.4779 z"
+               id="path7348" />
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               style="opacity:0.75800003;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+               d="m -65.732281,1064.3814 a 1.4779419,1.4779419 0 0 0 -1.477942,1.4779 1.4779419,1.4779419 0 0 0 1.477942,1.4779 1.4779419,1.4779419 0 0 0 1.477942,-1.4779 1.4779419,1.4779419 0 0 0 -1.477942,-1.4779 z"
+               id="path7350" />
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               style="opacity:0.75800003;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+               d="m -66.186054,1078.5977 a 1.4779419,1.4779419 0 0 0 -1.477942,1.478 1.4779419,1.4779419 0 0 0 1.477942,1.4779 1.4779419,1.4779419 0 0 0 1.477942,-1.4779 1.4779419,1.4779419 0 0 0 -1.477942,-1.478 z"
+               id="path7352" />
+            <path
+               inkscape:connector-curvature="0"
+               style="fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m -68.996411,1072.5815 c -0.53241,-9e-4 -11.924934,-0.1249 -12.430505,-0.1942 -4.25488,-0.583 -7.43339,-3.5466 -7.42091,-8.1863 0.0261,-9.7086 -0.12908,-17.2209 -0.12908,-17.2209"
+               id="path7354"
+               ns5245954:connector-curvature="0"
+               ns5422364:nodetypes="cssc" />
+            <path
+               inkscape:connector-curvature="0"
+               style="fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m -93.578606,991.0754 c 0,0 0.0602,-22.99365 0,-27.8256 -0.0503,-4.03426 -9.739284,-3.47253 -9.500004,-7.5 0.12244,-2.06088 0,-6.03694 0,-6.03694 l 0,0"
+               id="path7356"
+               ns5245954:connector-curvature="0"
+               ns5422364:nodetypes="csscc" />
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               id="path7358"
+               d="m -89.630946,991.05856 0.0884,-41.74382 0,0"
+               style="fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               ns5422364:nodetypes="ccc" />
+            <path
+               inkscape:connector-curvature="0"
+               style="fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m -84.946776,991.21389 c 0,0 -0.0272,-20.55865 -0.0366,-28.08908 -0.005,-3.92508 9.392135,-3.19996 9.375005,-7.12501 -0.01,-2.24626 0,-6.68506 0,-6.68506 l 0,0"
+               id="path7360"
+               ns5245954:connector-curvature="0"
+               ns5422364:nodetypes="csscc" />
+            <g
+               transform="matrix(0,1,-1,0,-358.59796,716.69444)"
+               style="font-style:normal;font-weight:normal;font-size:13.37965488px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="g7362">
+              <path
+                 inkscape:connector-curvature="0"
+                 ns5245954:connector-curvature="0"
+                 d="m 208.57404,-284.56981 1.39148,0 0,-1.72598 -1.39148,0 0,1.72598 z m 3.69278,4.34839 q 0,0.34787 -0.33449,0.61546 -0.33449,0.25421 -0.81616,0.25421 l -4.87019,0 0,-3.13083 2.32806,0 0,1.39148 1.39148,0 0,-1.73936 -2.55551,0 q -0.24084,0 -0.45491,-0.0669 -0.2007,-0.0669 -0.36125,-0.18732 -0.16056,-0.12042 -0.25421,-0.28097 -0.0937,-0.16056 -0.0937,-0.33449 l 0,-3.47871 q 0,-0.17394 0.0937,-0.3345 0.0936,-0.16055 0.25421,-0.28097 0.16055,-0.12041 0.36125,-0.18731 0.21407,-0.0669 0.45491,-0.0669 l 3.70616,0 q 0.48167,0 0.81616,0.26759 0.33449,0.25422 0.33449,0.60209 l 0,6.95742 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path7365" />
+              <path
+                 inkscape:connector-curvature="0"
+                 ns5245954:connector-curvature="0"
+                 d="m 214.51795,-288.04852 q -0.24083,0 -0.45491,0.0669 -0.20069,0.0669 -0.36125,0.18731 -0.16056,0.12042 -0.25421,0.28097 -0.0937,0.16056 -0.0937,0.3345 l 0,7.82709 2.34144,0 0,-6.95742 1.3781,0 0,6.95742 2.3013,0 0,-7.82709 q 0,-0.34787 -0.33449,-0.60209 -0.33449,-0.26759 -0.81616,-0.26759 l -3.70616,0 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path7367" />
+              <path
+                 inkscape:connector-curvature="0"
+                 ns5245954:connector-curvature="0"
+                 d="m 222.78992,-281.0911 1.39149,0 0,-5.20469 -1.39149,0 0,5.20469 z m 2.15413,-6.95742 q 0.81615,0.14717 1.05699,0.40139 0.28097,0.25421 0.45491,0.81616 l 0,6.26168 q -0.29436,0.6556 -0.52181,0.81615 -0.21407,0.17394 -1.09713,0.40139 l -4.37515,0 0,-8.69677 4.48219,0 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path7369" />
+            </g>
+            <g
+               transform="matrix(0,1,-1,0,-386.59796,716.69444)"
+               style="font-style:normal;font-weight:normal;font-size:13.37965488px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               id="g7371">
+              <path
+                 inkscape:connector-curvature="0"
+                 ns5245954:connector-curvature="0"
+                 d="m 210.38029,-296.42851 0,1.77949 -2.26116,0 0,-1.77949 -1.76612,0 0,-1.47176 1.83302,0 0,-2.02033 2.19426,0 0,2.02033 1.79287,0 0,1.47176 -1.79287,0 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path7373" />
+              <path
+                 inkscape:connector-curvature="0"
+                 ns5245954:connector-curvature="0"
+                 d="m 219.34863,-300.44241 0,-0.86967 q 0,-0.34787 -0.33449,-0.60209 -0.33449,-0.26759 -0.81616,-0.26759 l -3.70616,0 q -0.24084,0 -0.45491,0.0669 -0.2007,0.0669 -0.36125,0.18731 -0.16056,0.12042 -0.25422,0.28098 -0.0936,0.16055 -0.0936,0.33449 l 0,4.26811 3.71954,0 0,1.81963 -1.39148,0 0,-1.39148 -2.32806,0 0,2.26116 q 0,0.17393 0.0936,0.33449 0.0937,0.16055 0.25422,0.28097 0.16055,0.12042 0.36125,0.18732 0.21407,0.0669 0.45491,0.0669 l 3.70616,0 q 0.48167,0 0.81616,-0.25421 0.33449,-0.26759 0.33449,-0.61546 l 0,-4.25473 -3.69278,0 0,-1.83302 3.69278,0 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path7375" />
+              <path
+                 inkscape:connector-curvature="0"
+                 ns5245954:connector-curvature="0"
+                 d="m 220.39559,-302.18176 2.34144,0 0.70912,4.33501 0.73588,-4.33501 2.32806,0 -1.92667,8.69677 -2.24778,0 -1.94005,-8.69677 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path7377" />
+            </g>
+            <path
+               inkscape:connector-curvature="0"
+               ns5422364:nodetypes="csssc"
+               ns5245954:connector-curvature="0"
+               id="path7379"
+               d="m -65.857141,1065.8717 c -0.37092,-7e-4 -6.42242,3.0987 -12.12299,3.174 -1.483384,0.02 -3.206945,-0.5842 -4.093055,-1.2371 -1.65107,-1.2167 -2.70443,-3.2376 -2.69813,-5.8886 0.02,-8.4317 -0.099,-14.956 -0.099,-14.956"
+               style="fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            <path
+               inkscape:connector-curvature="0"
+               ns5422364:nodetypes="csssc"
+               ns5245954:connector-curvature="0"
+               id="path7381"
+               d="m -66.089161,1080.264 c -0.11596,-2e-4 -10.82325,-3.8889 -11.99182,-3.9069 -1.953974,-0.03 -4.498645,-0.072 -4.688385,-0.083 -5.93022,-0.3344 -10.507,-3.8252 -10.49011,-9.4973 0.0332,-11.1504 -0.16402,-19.7784 -0.16402,-19.7784"
+               style="fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            <g
+               id="text7383"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:26.97394562px;line-height:125%;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';letter-spacing:0px;word-spacing:0px;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="matrix(0,-1,-1,0,0,0)">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path5194"
+                 style="stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none"
+                 d="m -1068.8776,102.16012 -2.5085,0 q -0.3777,0.89014 -1.2139,0.89014 -0.2967,0 -0.8362,-0.10789 -0.5125,-0.1079 -1.2947,-0.29672 -0.8901,-0.26973 -1.5105,-0.37763 -0.5935,-0.1079 -0.8902,-0.1079 -1.1329,0 -1.9961,0.29672 -0.8631,0.26974 -1.4835,0.89014 l 0.054,-0.027 q -0.2697,0.21579 -0.4316,0.45856 -0.1618,0.24277 -0.2967,0.53948 l 0,-0.027 q -0.1079,0.16184 -0.2427,0.5125 -0.1079,0.32369 -0.3237,0.86317 l 3.2369,0 q 0.2427,-0.89014 1.0789,-0.94409 3.6685,0.89014 4.9902,0.89014 3.4257,0 4.154,-3.12898 l -0.4856,-0.32369 z" />
+            </g>
+          </g>
+          <path
+             inkscape:connector-curvature="0"
+             id="path6187"
+             d="m 95.212891,296.48438 c -1.086448,-10e-6 -1.978485,0.89206 -1.978516,1.97851 -4.3e-5,1.0865 0.892017,1.97852 1.978516,1.97852 1.086494,0 1.978558,-0.89203 1.978515,-1.97852 -3.1e-5,-1.08644 -0.892072,-1.97851 -1.978515,-1.97851 z"
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.75800003;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             sodipodi:nodetypes="scscs" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path6189"
+             d="m 81.601562,296.98438 c -1.086447,-10e-6 -1.978484,0.89206 -1.978515,1.97851 -4.3e-5,1.0865 0.892017,1.97852 1.978515,1.97852 1.086494,-1e-5 1.978559,-0.89203 1.978516,-1.97852 -3.1e-5,-1.08644 -0.892073,-1.97851 -1.978516,-1.97851 z"
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.75800003;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             sodipodi:nodetypes="scscs" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path6191"
+             d="m 67.833984,296.98438 c -1.086447,-10e-6 -1.978484,0.89206 -1.978515,1.97851 -4.3e-5,1.0865 0.892017,1.97852 1.978515,1.97852 1.086494,-1e-5 1.978559,-0.89203 1.978516,-1.97852 -3.1e-5,-1.08644 -0.892073,-1.97851 -1.978516,-1.97851 z"
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.75800003;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             sodipodi:nodetypes="scscs" />
+          <g
+             transform="matrix(0,-1,1,0,0,0)"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.66486835px;line-height:125%;font-family:Soviet;-inkscape-font-specification:Soviet;letter-spacing:0px;word-spacing:0px;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="text5045">
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               d="m -313.93149,93.566522 -3.64749,0 0,5.380036 c 0,0.253298 0.0861,0.471134 0.25837,0.653508 0.18237,0.172242 0.40021,0.258363 0.65351,0.258363 l 3.64748,0 c 0.25329,0 0.46606,-0.08612 0.63831,-0.258363 0.18237,-0.182374 0.27355,-0.40021 0.27356,-0.653508 l 0,-2.750809 -1.82374,0 0,1.823741 -1.82374,0 0,-2.841997 3.64748,0 0,-5.380036 c -10e-6,-0.253288 -0.0912,-0.466057 -0.27356,-0.63831 -0.17225,-0.182363 -0.38502,-0.27355 -0.63831,-0.273561 l -3.64748,0 c -0.2533,1.1e-5 -0.47114,0.0912 -0.65351,0.273561 -0.17224,0.172253 -0.25837,0.385022 -0.25837,0.63831 l 0,0.91187 3.64749,0 0,2.857195"
+               style="font-size:15.19784355px;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:4;stroke-dasharray:none"
+               id="path5089" />
+          </g>
+        </g>
+        <g
+           id="g6840"
+           style="fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1">
+          <g
+             transform="matrix(0,1.25,-1.25,0,-4.517521,784.41754)"
+             id="g6074"
+             style="display:inline;fill:none;stroke:#0000ff;stroke-width:0.05669291;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1">
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               id="path6076"
+               style="fill:none;stroke:#0000ff;stroke-width:0.05669291;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+               d="m 103.703,-242.148 0,-5.075 c 0,-0.461 -0.168,-0.855 -0.5,-1.179 -0.32,-0.332 -0.719,-0.496 -1.183,-0.496 l -6.731,0 c -0.461,0 -0.855,0.164 -1.187,0.496 -0.332,0.324 -0.5,0.718 -0.5,1.179 l 0,16.871 c 0,0.465 0.168,0.872 0.5,1.204 0.332,0.316 0.726,0.476 1.187,0.476 l 6.731,0 c 0.464,0 0.863,-0.16 1.183,-0.476 0.332,-0.332 0.5,-0.739 0.5,-1.204 l 0,-5.074 -3.367,0 0,3.371 -3.363,0 0,-5.234 6.73,0 0,-4.859 z m -3.367,1.886 -3.363,0 0,-5.254 3.363,0 0,5.254 z m 6.18,-8.636 10.097,0 0,6.75 -3.363,0 0,-3.368 -3.363,0 6.726,13.461 0,3.383 -10.097,0 0,-6.754 3.371,0 0,3.371 3.363,0 -6.734,-13.461 0,-3.382 z m 23.011,6.75 0,-5.075 c 0,-0.461 -0.164,-0.855 -0.496,-1.179 -0.324,-0.332 -0.719,-0.496 -1.191,-0.496 l -6.723,0 c -0.457,0 -0.851,0.164 -1.183,0.496 -0.332,0.324 -0.5,0.718 -0.5,1.179 l 0,16.871 c 0,0.465 0.168,0.872 0.5,1.204 0.332,0.316 0.726,0.476 1.183,0.476 l 6.723,0 c 0.472,0 0.867,-0.16 1.191,-0.476 0.332,-0.332 0.496,-0.739 0.496,-1.204 l 0,-5.074 -3.363,0 0,3.371 -3.371,0 0,-13.461 3.371,0 0,3.368 3.363,0 z" />
+          </g>
+          <g
+             id="g6078"
+             transform="matrix(0,0.97804301,0.97804301,0,233.68193,1104.6802)"
+             style="display:inline;fill:none;stroke:#0000ff;stroke-width:0.07245708;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1">
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               d="m -155.578,45.477 0,31.23 c 0,1.594 -1.289,2.879 -2.879,2.879 l -50.887,0 c -1.59,0 -2.875,-1.285 -2.875,-2.879 l 0,-31.23 c 0,-1.594 1.285,-2.875 2.875,-2.875 l 50.887,0 c 1.59,0 2.879,1.281 2.879,2.875 z"
+               style="fill:none;stroke:#0000ff;stroke-width:0.07245708;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+               id="path6080" />
+          </g>
+          <g
+             transform="matrix(0,-1,-1,0,24.788309,1046.8668)"
+             style="font-style:normal;font-weight:normal;font-size:27.48832321px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+             id="g6082">
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               d="m 69.116144,-303.3691 -0.944911,2.85192 -0.944911,-2.85192 -2.920634,0 0,11.16713 2.989355,0 0,-5.01661 0.87619,0.65284 0.910551,-0.65284 0,5.01661 2.954995,0 0,-11.16713 -2.920635,0 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:17.18020248px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+               id="path6084" />
+          </g>
+          <path
+             inkscape:connector-curvature="0"
+             ns5245954:connector-curvature="0"
+             style="display:inline;opacity:0.75800003;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             d="m 334.43168,969.1378 a 9.8529453,9.8529453 0 0 0 -9.85295,9.8529 9.8529453,9.8529453 0 0 0 9.85295,9.853 9.8529453,9.8529453 0 0 0 9.85294,-9.853 9.8529453,9.8529453 0 0 0 -9.85294,-9.8529 z"
+             id="path6088"
+             transform="translate(-12.000001,0)" />
+          <path
+             inkscape:connector-curvature="0"
+             ns5245954:connector-curvature="0"
+             style="display:inline;opacity:0.75800003;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             d="m 324.57131,977.2943 a 1.4779419,1.4779419 0 0 0 -1.47794,1.4779 1.4779419,1.4779419 0 0 0 1.47794,1.478 1.4779419,1.4779419 0 0 0 1.47794,-1.478 1.4779419,1.4779419 0 0 0 -1.47794,-1.4779 z"
+             id="path6090"
+             transform="translate(-12.000001,0)" />
+          <path
+             inkscape:connector-curvature="0"
+             ns5245954:connector-curvature="0"
+             style="display:inline;opacity:0.75800003;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             d="m 327.94945,970.25645 a 1.4779419,1.4779419 0 0 0 -1.47794,1.47795 1.4779419,1.4779419 0 0 0 1.47794,1.47794 1.4779419,1.4779419 0 0 0 1.47795,-1.47794 1.4779419,1.4779419 0 0 0 -1.47795,-1.47795 z"
+             id="path6092"
+             transform="translate(-12.000001,0)" />
+          <path
+             inkscape:connector-curvature="0"
+             ns5245954:connector-curvature="0"
+             style="display:inline;opacity:0.75800003;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             d="m 327.49568,984.4728 a 1.4779419,1.4779419 0 0 0 -1.47794,1.478 1.4779419,1.4779419 0 0 0 1.47794,1.4779 1.4779419,1.4779419 0 0 0 1.47794,-1.4779 1.4779419,1.4779419 0 0 0 -1.47794,-1.478 z"
+             id="path6094"
+             transform="translate(-12.000001,0)" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path6096"
+             d="m 290.57445,854.00644 a 1.4779419,1.4779419 0 0 0 -1.47794,1.47795 1.4779419,1.4779419 0 0 0 1.47794,1.47794 1.4779419,1.4779419 0 0 0 1.47794,-1.47794 1.4779419,1.4779419 0 0 0 -1.47794,-1.47795 z"
+             style="display:inline;opacity:0.75800003;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             ns5245954:connector-curvature="0"
+             transform="translate(-12.000001,0)" />
+          <path
+             inkscape:connector-curvature="0"
+             ns5245954:connector-curvature="0"
+             style="display:inline;opacity:0.75800003;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             d="m 304.1682,853.63144 a 1.4779419,1.4779419 0 0 0 -1.47794,1.47795 1.4779419,1.4779419 0 0 0 1.47794,1.47794 1.4779419,1.4779419 0 0 0 1.47794,-1.47794 1.4779419,1.4779419 0 0 0 -1.47794,-1.47795 z"
+             id="path6098"
+             transform="translate(-12.000001,0)" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path6100"
+             d="m 318.0432,853.44394 a 1.4779419,1.4779419 0 0 0 -1.47794,1.47795 1.4779419,1.4779419 0 0 0 1.47794,1.47794 1.4779419,1.4779419 0 0 0 1.47794,-1.47794 1.4779419,1.4779419 0 0 0 -1.47794,-1.47795 z"
+             style="display:inline;opacity:0.75800003;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             ns5245954:connector-curvature="0"
+             transform="translate(-12.000001,0)" />
+          <path
+             inkscape:connector-curvature="0"
+             style="display:inline;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+             d="m 324.68533,978.4566 c -0.53241,-9e-4 -11.92493,-0.1249 -12.43051,-0.1942 -4.25488,-0.583 -7.43339,-3.5466 -7.42091,-8.1863 0.0261,-9.7086 -0.12908,-17.2209 -0.12908,-17.2209"
+             id="path6110"
+             ns5245954:connector-curvature="0"
+             ns5422364:nodetypes="cssc"
+             transform="translate(-12.000001,0)" />
+          <path
+             inkscape:connector-curvature="0"
+             style="display:inline;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+             d="m 300.10313,896.9505 c 0,0 0.0602,-22.99365 0,-27.8256 -0.0503,-4.03426 -9.73928,-3.47253 -9.5,-7.5 0.12244,-2.06088 0,-6.03694 0,-6.03694"
+             id="path6112"
+             ns5245954:connector-curvature="0"
+             ns5422364:nodetypes="cssc"
+             transform="translate(-12.000001,0)" />
+          <path
+             inkscape:connector-curvature="0"
+             ns5245954:connector-curvature="0"
+             id="path6114"
+             d="m 304.05079,896.93366 0.0884,-41.74382 0,0"
+             style="display:inline;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+             ns5422364:nodetypes="ccc"
+             transform="translate(-12.000001,0)" />
+          <path
+             inkscape:connector-curvature="0"
+             style="display:inline;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+             d="m 308.73496,897.08899 c 0,0 -0.0272,-20.55865 -0.0366,-28.08908 -0.005,-3.92508 9.39214,-3.19996 9.37501,-7.12501 -0.01,-2.24626 0,-6.68506 0,-6.68506 l 0,0"
+             id="path6116"
+             ns5245954:connector-curvature="0"
+             ns5422364:nodetypes="csscc"
+             transform="translate(-12.000001,0)" />
+          <g
+             transform="matrix(0,1,-1,0,23.083779,622.56953)"
+             style="font-style:normal;font-weight:normal;font-size:13.37965488px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+             id="g6118">
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               d="m 208.57404,-284.56981 1.39148,0 0,-1.72598 -1.39148,0 0,1.72598 z m 3.69278,4.34839 q 0,0.34787 -0.33449,0.61546 -0.33449,0.25421 -0.81616,0.25421 l -4.87019,0 0,-3.13083 2.32806,0 0,1.39148 1.39148,0 0,-1.73936 -2.55551,0 q -0.24084,0 -0.45491,-0.0669 -0.2007,-0.0669 -0.36125,-0.18732 -0.16056,-0.12042 -0.25421,-0.28097 -0.0937,-0.16056 -0.0937,-0.33449 l 0,-3.47871 q 0,-0.17394 0.0937,-0.3345 0.0936,-0.16055 0.25421,-0.28097 0.16055,-0.12041 0.36125,-0.18731 0.21407,-0.0669 0.45491,-0.0669 l 3.70616,0 q 0.48167,0 0.81616,0.26759 0.33449,0.25422 0.33449,0.60209 l 0,6.95742 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+               id="path6120" />
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               d="m 214.51795,-288.04852 q -0.24083,0 -0.45491,0.0669 -0.20069,0.0669 -0.36125,0.18731 -0.16056,0.12042 -0.25421,0.28097 -0.0937,0.16056 -0.0937,0.3345 l 0,7.82709 2.34144,0 0,-6.95742 1.3781,0 0,6.95742 2.3013,0 0,-7.82709 q 0,-0.34787 -0.33449,-0.60209 -0.33449,-0.26759 -0.81616,-0.26759 l -3.70616,0 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+               id="path6122" />
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               d="m 222.78992,-281.0911 1.39149,0 0,-5.20469 -1.39149,0 0,5.20469 z m 2.15413,-6.95742 q 0.81615,0.14717 1.05699,0.40139 0.28097,0.25421 0.45491,0.81616 l 0,6.26168 q -0.29436,0.6556 -0.52181,0.81615 -0.21407,0.17394 -1.09713,0.40139 l -4.37515,0 0,-8.69677 4.48219,0 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+               id="path6124" />
+          </g>
+          <g
+             transform="matrix(0,1,-1,0,-4.916221,622.56953)"
+             style="font-style:normal;font-weight:normal;font-size:13.37965488px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+             id="g6126">
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               d="m 210.38029,-296.42851 0,1.77949 -2.26116,0 0,-1.77949 -1.76612,0 0,-1.47176 1.83302,0 0,-2.02033 2.19426,0 0,2.02033 1.79287,0 0,1.47176 -1.79287,0 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+               id="path6128" />
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               d="m 219.34863,-300.44241 0,-0.86967 q 0,-0.34787 -0.33449,-0.60209 -0.33449,-0.26759 -0.81616,-0.26759 l -3.70616,0 q -0.24084,0 -0.45491,0.0669 -0.2007,0.0669 -0.36125,0.18731 -0.16056,0.12042 -0.25422,0.28098 -0.0936,0.16055 -0.0936,0.33449 l 0,4.26811 3.71954,0 0,1.81963 -1.39148,0 0,-1.39148 -2.32806,0 0,2.26116 q 0,0.17393 0.0936,0.33449 0.0937,0.16055 0.25422,0.28097 0.16055,0.12042 0.36125,0.18732 0.21407,0.0669 0.45491,0.0669 l 3.70616,0 q 0.48167,0 0.81616,-0.25421 0.33449,-0.26759 0.33449,-0.61546 l 0,-4.25473 -3.69278,0 0,-1.83302 3.69278,0 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+               id="path6130" />
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               d="m 220.39559,-302.18176 2.34144,0 0.70912,4.33501 0.73588,-4.33501 2.32806,0 -1.92667,8.69677 -2.24778,0 -1.94005,-8.69677 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+               id="path6132" />
+          </g>
+          <path
+             inkscape:connector-curvature="0"
+             ns5422364:nodetypes="csssc"
+             ns5245954:connector-curvature="0"
+             id="path6134"
+             d="m 327.8246,971.7468 c -0.37092,-7e-4 -6.42242,3.0987 -12.12299,3.174 -1.48339,0.02 -3.20695,-0.5842 -4.09306,-1.2371 -1.65107,-1.2167 -2.70443,-3.2376 -2.69813,-5.8886 0.02,-8.4317 -0.099,-14.956 -0.099,-14.956"
+             style="display:inline;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+             transform="translate(-12.000001,0)" />
+          <path
+             inkscape:connector-curvature="0"
+             ns5422364:nodetypes="csssc"
+             ns5245954:connector-curvature="0"
+             id="path6136"
+             d="m 327.59258,986.1391 c -0.11596,-2e-4 -10.82325,-3.8889 -11.99182,-3.9069 -1.95398,-0.03 -4.49865,-0.072 -4.68839,-0.083 -5.93022,-0.3344 -10.507,-3.8252 -10.49011,-9.4973 0.0332,-11.1504 -0.16402,-19.7784 -0.16402,-19.7784"
+             style="display:inline;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+             transform="translate(-12.000001,0)" />
+          <g
+             id="text6138"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:26.97394562px;line-height:125%;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';letter-spacing:0px;word-spacing:0px;display:inline;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+             transform="matrix(0,-1,-1,0,-12.000001,0)">
+            <path
+               inkscape:connector-curvature="0"
+               id="path5191"
+               style="fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+               d="m -973.38561,-289.74909 -2.50858,0 q -0.37763,0.89014 -1.21383,0.89014 -0.29671,0 -0.83619,-0.1079 -0.5125,-0.1079 -1.29475,-0.29671 -0.89014,-0.26974 -1.51054,-0.37764 -0.59342,-0.10789 -0.89014,-0.10789 -1.1329,0 -1.99607,0.29671 -0.86317,0.26974 -1.48357,0.89014 l 0.0539,-0.027 q -0.26974,0.21579 -0.43158,0.45855 -0.16185,0.24277 -0.29672,0.53948 l 0,-0.027 q -0.10789,0.16184 -0.24276,0.5125 -0.1079,0.32369 -0.32369,0.86317 l 3.23687,0 q 0.24277,-0.89014 1.07896,-0.94409 3.66846,0.89014 4.99018,0.89014 3.42569,0 4.15399,-3.12898 l -0.48553,-0.32368 z" />
+          </g>
+          <g
+             transform="matrix(0,1,-1,0,0,0)"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.27807045px;line-height:125%;font-family:Soviet;-inkscape-font-specification:Soviet;letter-spacing:0px;word-spacing:0px;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+             id="text5049">
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               d="m 835.54706,-281.14959 0,-3.31839 c -10e-6,-0.30555 0.10389,-0.56222 0.31167,-0.77002 0.22,-0.21999 0.48278,-0.32999 0.78835,-0.33001 l 4.40008,0 c 0.30556,2e-5 0.56223,0.11002 0.77002,0.33001 0.21999,0.2078 0.32999,0.46447 0.33,0.77002 l 0,11.03687 c -1e-5,0.30557 -0.11001,0.56835 -0.33,0.78835 -0.20779,0.20778 -0.46446,0.31167 -0.77002,0.31167 l -4.40008,0 c -0.30557,0 -0.56835,-0.10389 -0.78835,-0.31167 -0.20778,-0.22 -0.31168,-0.48278 -0.31167,-0.78835 l 0,-3.31839 2.20004,0 0,2.20004 2.20004,0 0,-3.4284 -1.98004,0 0,-1.94337 1.98004,0 0,-3.4284 -2.20004,0 0,2.20004 -2.20004,0"
+               style="font-size:18.33368492px;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+               id="path5107" />
+          </g>
+        </g>
+        <g
+           id="g6873"
+           style="stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none">
+          <g
+             style="stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+             transform="translate(170.50002,83.50001)"
+             id="g7132">
+            <g
+               style="stroke:#0000ff;stroke-width:0.05669291;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+               id="g7074"
+               transform="matrix(0,-1.25,1.25,0,208.76324,892.45379)">
+              <path
+                 inkscape:connector-curvature="0"
+                 d="m 103.703,-242.148 0,-5.075 c 0,-0.461 -0.168,-0.855 -0.5,-1.179 -0.32,-0.332 -0.719,-0.496 -1.183,-0.496 l -6.731,0 c -0.461,0 -0.855,0.164 -1.187,0.496 -0.332,0.324 -0.5,0.718 -0.5,1.179 l 0,16.871 c 0,0.465 0.168,0.872 0.5,1.204 0.332,0.316 0.726,0.476 1.187,0.476 l 6.731,0 c 0.464,0 0.863,-0.16 1.183,-0.476 0.332,-0.332 0.5,-0.739 0.5,-1.204 l 0,-5.074 -3.367,0 0,3.371 -3.363,0 0,-5.234 6.73,0 0,-4.859 z m -3.367,1.886 -3.363,0 0,-5.254 3.363,0 0,5.254 z m 6.18,-8.636 10.097,0 0,6.75 -3.363,0 0,-3.368 -3.363,0 6.726,13.461 0,3.383 -10.097,0 0,-6.754 3.371,0 0,3.371 3.363,0 -6.734,-13.461 0,-3.382 z m 23.011,6.75 0,-5.075 c 0,-0.461 -0.164,-0.855 -0.496,-1.179 -0.324,-0.332 -0.719,-0.496 -1.191,-0.496 l -6.723,0 c -0.457,0 -0.851,0.164 -1.183,0.496 -0.332,0.324 -0.5,0.718 -0.5,1.179 l 0,16.871 c 0,0.465 0.168,0.872 0.5,1.204 0.332,0.316 0.726,0.476 1.183,0.476 l 6.723,0 c 0.472,0 0.867,-0.16 1.191,-0.476 0.332,-0.332 0.496,-0.739 0.496,-1.204 l 0,-5.074 -3.363,0 0,3.371 -3.371,0 0,-13.461 3.371,0 0,3.368 3.363,0 z"
+                 style="fill:none;stroke:#0000ff;stroke-width:0.05669291;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+                 id="path7076"
+                 ns5245954:connector-curvature="0" />
+            </g>
+            <g
+               style="stroke:#0000ff;stroke-width:0.07245708;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+               transform="matrix(0,0.97804301,-0.97804301,0,-30.208085,933.30504)"
+               id="g7082">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path7084"
+                 style="fill:none;stroke:#0000ff;stroke-width:0.07245708;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+                 d="m -155.578,45.477 0,31.23 c 0,1.594 -1.289,2.879 -2.879,2.879 l -50.887,0 c -1.59,0 -2.875,-1.285 -2.875,-2.879 l 0,-31.23 c 0,-1.594 1.285,-2.875 2.875,-2.875 l 50.887,0 c 1.59,0 2.879,1.281 2.879,2.875 z"
+                 ns5245954:connector-curvature="0" />
+            </g>
+            <g
+               id="g7086"
+               style="font-style:normal;font-weight:normal;font-size:27.48832321px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+               transform="matrix(0,-1,1,0,178.68554,875.4917)">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path7088"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:17.18020248px;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+                 d="m 69.116144,-303.3691 -0.944911,2.85192 -0.944911,-2.85192 -2.920634,0 0,11.16713 2.989355,0 0,-5.01661 0.87619,0.65284 0.910551,-0.65284 0,5.01661 2.954995,0 0,-11.16713 -2.920635,0 z"
+                 ns5245954:connector-curvature="0" />
+            </g>
+            <g
+               style="stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+               transform="matrix(0,-1,1,0,-193.34147,1105.1414)"
+               id="g7090">
+              <path
+                 inkscape:connector-curvature="0"
+                 ns5245954:connector-curvature="0"
+                 style="opacity:0.75800003;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+                 d="m 307.3787,74.383632 a 9.8529453,9.8529453 0 0 1 -9.85294,9.852946 9.8529453,9.8529453 0 0 1 -9.85295,-9.852946 9.8529453,9.8529453 0 0 1 9.85295,-9.852945 9.8529453,9.8529453 0 0 1 9.85294,9.852945 z"
+                 id="path7092" />
+              <path
+                 inkscape:connector-curvature="0"
+                 ns5245954:connector-curvature="0"
+                 style="opacity:0.75800003;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+                 d="m 299.2222,84.243999 a 1.4779419,1.4779419 0 0 1 -1.47794,1.477942 1.4779419,1.4779419 0 0 1 -1.47794,-1.477942 1.4779419,1.4779419 0 0 1 1.47794,-1.477942 1.4779419,1.4779419 0 0 1 1.47794,1.477942 z"
+                 id="path7094" />
+              <path
+                 inkscape:connector-curvature="0"
+                 ns5245954:connector-curvature="0"
+                 style="opacity:0.75800003;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+                 d="m 306.26005,80.865856 a 1.4779419,1.4779419 0 0 1 -1.47795,1.477942 1.4779419,1.4779419 0 0 1 -1.47794,-1.477942 1.4779419,1.4779419 0 0 1 1.47794,-1.477942 1.4779419,1.4779419 0 0 1 1.47795,1.477942 z"
+                 id="path7096" />
+              <path
+                 inkscape:connector-curvature="0"
+                 ns5245954:connector-curvature="0"
+                 style="opacity:0.75800003;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+                 d="m 292.04368,81.319629 a 1.4779419,1.4779419 0 0 1 -1.47795,1.477942 1.4779419,1.4779419 0 0 1 -1.47794,-1.477942 1.4779419,1.4779419 0 0 1 1.47794,-1.477942 1.4779419,1.4779419 0 0 1 1.47795,1.477942 z"
+                 id="path7098" />
+            </g>
+            <path
+               inkscape:connector-curvature="0"
+               ns5422364:nodetypes="cssc"
+               ns5245954:connector-curvature="0"
+               id="path7100"
+               d="m -109.21148,807.08146 c 0.53241,-8.7e-4 11.924934,-0.12492 12.430505,-0.19419 4.25488,-0.58299 7.43339,-3.54655 7.42091,-8.18635 -0.0261,-9.70853 0.12908,-17.22087 0.12908,-17.22087"
+               style="fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1" />
+            <path
+               inkscape:connector-curvature="0"
+               ns5422364:nodetypes="csscc"
+               ns5245954:connector-curvature="0"
+               id="path7102"
+               d="m -84.629285,725.57537 c 0,0 -0.0602,-22.99365 0,-27.8256 0.0503,-4.03426 9.73928,-3.47253 9.5,-7.5 -0.12244,-2.06088 0,-6.03694 0,-6.03694 l 0,0"
+               style="fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1" />
+            <path
+               inkscape:connector-curvature="0"
+               ns5422364:nodetypes="ccc"
+               style="fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+               d="m -88.576945,725.55853 -0.0884,-41.74382 0,0"
+               id="path7104"
+               ns5245954:connector-curvature="0" />
+            <path
+               inkscape:connector-curvature="0"
+               ns5422364:nodetypes="csscc"
+               ns5245954:connector-curvature="0"
+               id="path7106"
+               d="m -93.261115,725.71386 c 0,0 0.0272,-20.55865 0.0366,-28.08908 0.005,-3.92508 -9.392135,-3.19996 -9.375005,-7.12501 0.01,-2.24626 0,-6.68506 0,-6.68506 l 0,0"
+               style="fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1" />
+            <g
+               id="g7108"
+               style="font-style:normal;font-weight:normal;font-size:13.37965488px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+               transform="matrix(0,-1,1,0,180.43554,884.4917)">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path7110"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+                 d="m 208.57404,-284.56981 1.39148,0 0,-1.72598 -1.39148,0 0,1.72598 z m 3.69278,4.34839 q 0,0.34787 -0.33449,0.61546 -0.33449,0.25421 -0.81616,0.25421 l -4.87019,0 0,-3.13083 2.32806,0 0,1.39148 1.39148,0 0,-1.73936 -2.55551,0 q -0.24084,0 -0.45491,-0.0669 -0.2007,-0.0669 -0.36125,-0.18732 -0.16056,-0.12042 -0.25421,-0.28097 -0.0937,-0.16056 -0.0937,-0.33449 l 0,-3.47871 q 0,-0.17394 0.0937,-0.3345 0.0936,-0.16055 0.25421,-0.28097 0.16055,-0.12041 0.36125,-0.18731 0.21407,-0.0669 0.45491,-0.0669 l 3.70616,0 q 0.48167,0 0.81616,0.26759 0.33449,0.25422 0.33449,0.60209 l 0,6.95742 z"
+                 ns5245954:connector-curvature="0" />
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path7112"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+                 d="m 214.51795,-288.04852 q -0.24083,0 -0.45491,0.0669 -0.20069,0.0669 -0.36125,0.18731 -0.16056,0.12042 -0.25421,0.28097 -0.0937,0.16056 -0.0937,0.3345 l 0,7.82709 2.34144,0 0,-6.95742 1.3781,0 0,6.95742 2.3013,0 0,-7.82709 q 0,-0.34787 -0.33449,-0.60209 -0.33449,-0.26759 -0.81616,-0.26759 l -3.70616,0 z"
+                 ns5245954:connector-curvature="0" />
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path7114"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+                 d="m 222.78992,-281.0911 1.39149,0 0,-5.20469 -1.39149,0 0,5.20469 z m 2.15413,-6.95742 q 0.81615,0.14717 1.05699,0.40139 0.28097,0.25421 0.45491,0.81616 l 0,6.26168 q -0.29436,0.6556 -0.52181,0.81615 -0.21407,0.17394 -1.09713,0.40139 l -4.37515,0 0,-8.69677 4.48219,0 z"
+                 ns5245954:connector-curvature="0" />
+            </g>
+            <g
+               id="g7116"
+               style="font-style:normal;font-weight:normal;font-size:13.37965488px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+               transform="matrix(0,-1,1,0,208.43554,884.4917)">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path7118"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+                 d="m 210.38029,-296.42851 0,1.77949 -2.26116,0 0,-1.77949 -1.76612,0 0,-1.47176 1.83302,0 0,-2.02033 2.19426,0 0,2.02033 1.79287,0 0,1.47176 -1.79287,0 z"
+                 ns5245954:connector-curvature="0" />
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path7120"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+                 d="m 219.34863,-300.44241 0,-0.86967 q 0,-0.34787 -0.33449,-0.60209 -0.33449,-0.26759 -0.81616,-0.26759 l -3.70616,0 q -0.24084,0 -0.45491,0.0669 -0.2007,0.0669 -0.36125,0.18731 -0.16056,0.12042 -0.25422,0.28098 -0.0936,0.16055 -0.0936,0.33449 l 0,4.26811 3.71954,0 0,1.81963 -1.39148,0 0,-1.39148 -2.32806,0 0,2.26116 q 0,0.17393 0.0936,0.33449 0.0937,0.16055 0.25422,0.28097 0.16055,0.12042 0.36125,0.18732 0.21407,0.0669 0.45491,0.0669 l 3.70616,0 q 0.48167,0 0.81616,-0.25421 0.33449,-0.26759 0.33449,-0.61546 l 0,-4.25473 -3.69278,0 0,-1.83302 3.69278,0 z"
+                 ns5245954:connector-curvature="0" />
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path7122"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+                 d="m 220.39559,-302.18176 2.34144,0 0.70912,4.33501 0.73588,-4.33501 2.32806,0 -1.92667,8.69677 -2.24778,0 -1.94005,-8.69677 z"
+                 ns5245954:connector-curvature="0" />
+            </g>
+            <path
+               inkscape:connector-curvature="0"
+               style="fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+               d="m -112.35075,800.37162 c 0.37092,-6.8e-4 6.42242,3.09873 12.12299,3.174 1.483384,0.0196 3.206945,-0.58411 4.093055,-1.23709 1.65107,-1.21667 2.70443,-3.23758 2.69813,-5.88852 -0.02,-8.43171 0.099,-14.95608 0.099,-14.95608"
+               id="path7124"
+               ns5245954:connector-curvature="0"
+               ns5422364:nodetypes="csssc" />
+            <path
+               inkscape:connector-curvature="0"
+               style="fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+               d="m -112.11873,814.76395 c 0.11596,-1.8e-4 10.82325,-3.8889 11.99182,-3.9069 1.953974,-0.0301 4.498645,-0.0722 4.688385,-0.0829 5.93022,-0.33436 10.507,-3.82521 10.49011,-9.49726 -0.0332,-11.1504 0.16402,-19.77844 0.16402,-19.77844"
+               id="path7126"
+               ns5245954:connector-curvature="0"
+               ns5422364:nodetypes="csssc" />
+            <g
+               id="text7128"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:expanded;font-size:26.97394562px;line-height:125%;font-family:'Soviet Bold Expanded';-inkscape-font-specification:'Soviet Bold Expanded, Bold Expanded';letter-spacing:0px;word-spacing:0px;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+               transform="matrix(0,-1,1,0,0,0)">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path5197"
+                 style="stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none"
+                 d="m -798.26043,-74.525255 -2.50857,0 q -0.37764,0.89014 -1.21383,0.89014 -0.29672,0 -0.83619,-0.107896 -0.51251,-0.107896 -1.29475,-0.296713 -0.89014,-0.26974 -1.51054,-0.377636 -0.59343,-0.107895 -0.89015,-0.107895 -1.1329,0 -1.99607,0.296713 -0.86316,0.269739 -1.48356,0.89014 l 0.0539,-0.02697 q -0.26974,0.215792 -0.43158,0.458557 -0.16184,0.242766 -0.29671,0.539479 l 0,-0.02697 q -0.1079,0.161844 -0.24277,0.512505 -0.10789,0.323688 -0.32369,0.863167 l 3.23688,0 q 0.24276,-0.890141 1.07896,-0.944089 3.66845,0.890141 4.99018,0.890141 3.42569,0 4.15398,-3.128978 l -0.48553,-0.323687 z" />
+            </g>
+          </g>
+          <path
+             inkscape:connector-curvature="0"
+             id="path6102"
+             d="m 95.304688,766.00586 c -1.086468,0 -1.978522,0.89205 -1.978516,1.97852 10e-7,1.08646 0.892053,1.97851 1.978516,1.97851 1.086462,0 1.978514,-0.89205 1.978515,-1.97851 6e-6,-1.08647 -0.892048,-1.97852 -1.978515,-1.97852 z"
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.75800003;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             sodipodi:nodetypes="sssss" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path6104"
+             d="m 81.796875,765.63086 c -1.086468,0 -1.978522,0.89205 -1.978516,1.97852 2e-6,1.08646 0.892053,1.97851 1.978516,1.97851 1.086463,0 1.976561,-0.89205 1.976563,-1.97851 5e-6,-1.08647 -0.890095,-1.97852 -1.976563,-1.97852 z"
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.75800003;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             sodipodi:nodetypes="sssss" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path6106"
+             d="m 68.080078,765.68359 c -1.086468,10e-6 -1.976568,0.89205 -1.976562,1.97852 10e-7,1.08646 0.890099,1.97656 1.976562,1.97656 1.086463,0 1.978514,-0.8901 1.978516,-1.97656 6e-6,-1.08647 -0.892048,-1.97851 -1.978516,-1.97852 z"
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.75800003;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0000ff;stroke-width:0.07086614;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             sodipodi:nodetypes="csssc" />
+          <g
+             transform="matrix(0,-1,1,0,0,0)"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.88349533px;line-height:125%;font-family:Soviet;-inkscape-font-specification:Soviet;letter-spacing:0px;word-spacing:0px;fill:none;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none;stroke-opacity:1"
+             id="text5053">
+            <path
+               inkscape:connector-curvature="0"
+               ns5245954:connector-curvature="0"
+               d="m -753.89892,91.225602 0,-2.161083 4.28645,0 0,10.733977 2.14322,0 0,2.161084 -6.42967,0 0,-2.161084 2.14322,0 0,-8.572894 -2.14322,0"
+               style="font-size:17.86019516px;stroke:#0000ff;stroke-width:0.07086614;stroke-miterlimit:5.25648546;stroke-dasharray:none"
+               id="path5110" />
+          </g>
+        </g>
+        <path
+           inkscape:connector-curvature="0"
+           ns5245954:connector-curvature="0"
+           id="path5207"
+           d="m 850.99155,698.33104 3.14473,-0.12449 -5.38141,9.62562 4.99759,-0.12756 -6.95461,10.38516 3.9714,-9.1935 -5.18985,-0.0622 z"
+           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:0.03904166;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           sodipodi:nodetypes="cccccccc" />
+        <path
+           style="fill:none;fill-rule:evenodd;stroke:#0000ff;stroke-width:0.03543307;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 515.76626,921.43475 9.28931,9.2893 3.91823,-3.83019 -1.761,-1.76101 0,0"
+           id="path5209"
+           inkscape:connector-curvature="0" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path5213"
+           d="m 518.21357,938.38329 -9.67928,-9.78827 3.68592,-3.77108 2.15251,1.99937"
+           style="fill:none;fill-rule:evenodd;stroke:#0000ff;stroke-width:0.02350808;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           sodipodi:nodetypes="cccc" />
+        <path
+           style="fill:none;fill-rule:evenodd;stroke:#0000ff;stroke-width:0.03543307;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 515.14991,931.38442 -1.89309,2.02516 0,0 0,0"
+           id="path5215"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccc" />
+        <path
+           style="fill:none;fill-rule:evenodd;stroke:#0000ff;stroke-width:0.03543307;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 524.39519,912.58568 1.98113,2.15724 2.02516,-1.84906 5.37107,5.15094 -1.98114,1.76102 2.24529,2.2893 0,0 0,0"
+           id="path5217"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccc" />
+        <path
+           style="fill:none;fill-rule:evenodd;stroke:#0000ff;stroke-width:0.03543307;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 526.37633,914.78695 -1.76102,1.76101 5.28302,5.06289 1.93711,-1.80503 0,0"
+           id="path5219"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="fill:none;fill-rule:evenodd;stroke:#0000ff;stroke-width:0.03543307;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 539.31972,916.54795 -9.46541,-9.55345 3.83019,-3.69813 9.59748,9.9497 0,0"
+           id="path5221"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;fill-rule:evenodd;stroke:#0000ff;stroke-width:0.03543307;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 542.0933,904.44104 3.69811,-3.65409 -4.93081,-4.62264 -3.56604,3.61005 9.42138,9.55346 3.74214,-3.56604 -2.06918,-2.02516 0,0"
+           id="path5223"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Hi guys,

I got an email from Lot the other day, letting me know that you used some stuff from http://parametric-svg.js.org at http://frame.flone.cc. Of course, it’s no problem! It’s an honor to have a tiny share in your amazing project! A friendly mention would be very nice, but don’t feel obliged to put it there. I also mentioned your project at https://github.com/parametric-svg/-/#in-the-wild.

By the way, I really think _parametric-svg_ is a perfect match for your use case! There are two things that make it stand out – for one, it’s an open, language-independent spec, fully based on open standards. This means every parametric-svg file is a valid SVG – just like e. g. every Inkscape file is a valid SVG. The second thing is performance. After the download and initial parse time (these are yet to be optimized), you can recompute a complex model within one or two frames.

But yeah – I haven’t had much time lately to make easy-to-use tools for it. An editor similar to that at [fablabamersfoort.nl/svg](http://www.fablabamersfoort.nl/svg/) is definitely on the roadmap – as well as a command-line renderer and a native, cross-platform live viewer. I just haven’t had the time to make the thing more user friendly. As soon as I get a couple of free afternoons, I’m considering joining forces with the folks at Fab Lab Amersfoort and push the thing forward.

However, I’ve had a quick go at a miniature one-off app for you. Here’s what the thing looks like with parametric-svg: [tomekwi.github.io/flone-frame](http://tomekwi.github.io/flone-frame/). In this PR I’m sending you your file converted to _parametric-svg_. As well as that, feel free to take and use the `gh-pages` branch from my repo if you wish.
